### PR TITLE
[codex] Fix binary reads and surface OAuth restart status

### DIFF
--- a/README.md
+++ b/README.md
@@ -236,6 +236,15 @@ The Claude desktop and mobile apps can connect to remote MCP servers via OAuth.
 
 For local-only use (no tunnel), point Claude at `http://localhost:8420`.
 
+If Claude or ChatGPT asks to reauthenticate after a server restart, verify these first:
+
+1. `VAULT_OAUTH_PERSIST_REGISTERED_CLIENTS=true`
+2. `VAULT_REGISTERED_CLIENT_TTL_SECONDS=0`
+3. `VAULT_PUBLIC_BASE_URL` is set explicitly for your public tunnel hostname
+4. `GET /health` shows `oauth.registered_client_store_exists=true` and `oauth.restart_stable_reconnects=true`
+
+This fork now exposes those restart-relevant OAuth settings in `/health` and logs them once during startup so operator mistakes are easier to spot.
+
 ### Connecting to ChatGPT
 
 ChatGPT can use the same deployed MCP endpoint, but connector behavior may vary a bit more by rollout and client version than Claude does.

--- a/docs/deploy/operations-runbook.md
+++ b/docs/deploy/operations-runbook.md
@@ -63,6 +63,19 @@ Recommended operator order:
 - `VAULT_REGISTERED_CLIENT_TTL_SECONDS=0` disables automatic expiry and is the recommended single-user setting for stable ChatGPT and Claude reconnects.
 - Keep `VAULT_MAX_REGISTERED_CLIENTS` as the safety cap so very old registrations can still be trimmed if the store ever grows unexpectedly.
 
+Restart-safe checklist:
+
+1. Keep `VAULT_OAUTH_PERSIST_REGISTERED_CLIENTS=true`.
+2. Keep `VAULT_REGISTERED_CLIENT_TTL_SECONDS=0`.
+3. Set `VAULT_PUBLIC_BASE_URL` explicitly when you run behind Cloudflare Tunnel or another reverse proxy.
+4. Keep `VAULT_OAUTH_REGISTERED_CLIENT_STORE_PATH` on persistent disk, not in a temp directory.
+5. After a restart, open `GET /health` and confirm the `oauth` block reports:
+   - `registered_client_persistence_enabled=true`
+   - `registered_client_store_exists=true`
+   - `restart_stable_reconnects=true`
+
+If those values are correct and the connector still asks for reauthentication after a restart, the remaining problem is likely client-side reconnect behavior rather than missing server-side persistence.
+
 ## Vault Analytics
 
 Use analytics for read-only hygiene checks, not as an auto-fix path.

--- a/src/obsidian_vault_mcp/server.py
+++ b/src/obsidian_vault_mcp/server.py
@@ -60,6 +60,66 @@ def _truncate_log_value(value: Any, limit: int = 120) -> str:
     return text
 
 
+def _oauth_health_payload() -> dict[str, Any]:
+    """Expose the restart-relevant OAuth runtime configuration."""
+    store_path = config.VAULT_OAUTH_REGISTERED_CLIENT_STORE_PATH
+    restart_stable = (
+        config.VAULT_OAUTH_PERSIST_REGISTERED_CLIENTS
+        and config.REGISTERED_CLIENT_TTL_SECONDS == 0
+    )
+    return {
+        "public_base_url_configured": bool(config.VAULT_PUBLIC_BASE_URL),
+        "registered_client_persistence_enabled": config.VAULT_OAUTH_PERSIST_REGISTERED_CLIENTS,
+        "registered_client_store_path": str(store_path),
+        "registered_client_store_exists": store_path.exists(),
+        "registered_client_ttl_seconds": config.REGISTERED_CLIENT_TTL_SECONDS,
+        "max_registered_clients": config.MAX_REGISTERED_CLIENTS,
+        "restart_stable_reconnects": restart_stable,
+    }
+
+
+def _log_oauth_runtime_summary() -> None:
+    """Log the OAuth settings that determine restart-safe reconnect behavior."""
+    oauth_status = _oauth_health_payload()
+    logger.info(
+        "OAuth runtime: public_base_url_configured=%s persistence_enabled=%s "
+        "store=%s store_exists=%s ttl_seconds=%s max_registered_clients=%s "
+        "restart_stable_reconnects=%s",
+        oauth_status["public_base_url_configured"],
+        oauth_status["registered_client_persistence_enabled"],
+        oauth_status["registered_client_store_path"],
+        oauth_status["registered_client_store_exists"],
+        oauth_status["registered_client_ttl_seconds"],
+        oauth_status["max_registered_clients"],
+        oauth_status["restart_stable_reconnects"],
+    )
+
+    if not oauth_status["registered_client_persistence_enabled"]:
+        logger.warning(
+            "OAuth registered-client persistence is disabled; connectors may "
+            "require re-registration after every server restart"
+        )
+    elif oauth_status["registered_client_ttl_seconds"] != 0:
+        logger.warning(
+            "OAuth registered-client TTL is %ss; connectors may require "
+            "re-registration after expiry. Set "
+            "VAULT_REGISTERED_CLIENT_TTL_SECONDS=0 for stable reconnects",
+            oauth_status["registered_client_ttl_seconds"],
+        )
+
+    if not oauth_status["public_base_url_configured"]:
+        logger.info(
+            "VAULT_PUBLIC_BASE_URL is not set; explicit configuration is "
+            "recommended behind tunnels and reverse proxies for stable OAuth discovery"
+        )
+
+    if oauth_status["registered_client_persistence_enabled"] and not oauth_status["registered_client_store_exists"]:
+        logger.info(
+            "No persisted OAuth client registration store found yet at %s",
+            oauth_status["registered_client_store_path"],
+        )
+
+
 def _run_logged_tool(name: str, func: Callable[[], str], **context: Any) -> str:
     """Run one MCP tool call with consistent start/end/error logging."""
     started = time.monotonic()
@@ -150,6 +210,7 @@ def _health_payload() -> dict:
             "chunk_count": semantic_status["chunk_count"],
             "reason": semantic_status["reason"],
         },
+        "oauth": _oauth_health_payload(),
         "heartbeat": dict(_heartbeat_state),
         "uptime_seconds": round(time.monotonic() - _server_started_at, 3),
     }
@@ -684,6 +745,7 @@ def main():
         logger.warning("VAULT_MCP_TOKEN is not set -- auth will reject all requests")
 
     try:
+        _log_oauth_runtime_summary()
         app = build_app()
         logger.info(f"Starting server on port {VAULT_MCP_PORT} with bearer auth + OAuth")
 

--- a/src/obsidian_vault_mcp/vault.py
+++ b/src/obsidian_vault_mcp/vault.py
@@ -10,6 +10,35 @@ from pathlib import Path
 
 from . import config
 
+UNSUPPORTED_BINARY_EXTENSIONS = frozenset({
+    ".7z",
+    ".avi",
+    ".bmp",
+    ".doc",
+    ".docx",
+    ".eml",
+    ".gif",
+    ".gz",
+    ".jpeg",
+    ".jpg",
+    ".mov",
+    ".mp3",
+    ".mp4",
+    ".msg",
+    ".pdf",
+    ".png",
+    ".ppt",
+    ".pptx",
+    ".rar",
+    ".tar",
+    ".tiff",
+    ".wav",
+    ".webp",
+    ".xls",
+    ".xlsx",
+    ".zip",
+})
+
 
 class _DateAwareEncoder(json.JSONEncoder):
     """JSON encoder that serialises date/datetime objects to ISO 8601 strings.
@@ -61,6 +90,16 @@ def _iso_timestamp(ts: float) -> str:
     return datetime.fromtimestamp(ts, tz=timezone.utc).isoformat()
 
 
+def _reject_unsupported_binary(path: Path) -> None:
+    """Reject known binary formats before attempting UTF-8 text reads."""
+    suffix = path.suffix.lower()
+    if suffix in UNSUPPORTED_BINARY_EXTENSIONS:
+        raise ValueError(
+            f"Binary file type {suffix} is not supported by vault_read. "
+            "Use a dedicated binary/PDF reader."
+        )
+
+
 def read_file(relative_path: str) -> tuple[str, dict]:
     """Read a file and return (content, metadata).
 
@@ -70,6 +109,8 @@ def read_file(relative_path: str) -> tuple[str, dict]:
 
     if not path.is_file():
         raise FileNotFoundError(f"Not a file: {relative_path}")
+
+    _reject_unsupported_binary(path)
 
     stat = path.stat()
     content = path.read_text(encoding="utf-8")

--- a/tests/test_security.py
+++ b/tests/test_security.py
@@ -652,6 +652,8 @@ def test_build_app_exposes_health_without_bearer(vault_dir, monkeypatch):
     assert body["status"] == "ok"
     assert body["vault"]["exists"] is True
     assert body["frontmatter_index"]["active"] is False
+    assert body["oauth"]["registered_client_persistence_enabled"] is True
+    assert "restart_stable_reconnects" in body["oauth"]
     assert "heartbeat" in body
     assert "uptime_seconds" in body
 
@@ -674,6 +676,33 @@ def test_health_reflects_heartbeat_configuration(vault_dir, monkeypatch):
     assert body["heartbeat"]["enabled"] is True
     assert body["heartbeat"]["url"] == "https://hc.example/ping"
     assert body["heartbeat"]["interval_seconds"] == 90
+
+
+def test_health_reflects_oauth_restart_configuration(vault_dir, monkeypatch, tmp_path):
+    """Health payload should expose restart-relevant OAuth persistence settings."""
+    reset_rate_limits()
+    base_app = Starlette()
+    store_path = tmp_path / "oauth_registered_clients.json"
+    store_path.write_text("{}", encoding="utf-8")
+    monkeypatch.setattr(server, "VAULT_PATH", vault_dir)
+    monkeypatch.setattr(server, "VAULT_MCP_TOKEN", "test-token-12345")
+    monkeypatch.setattr(server.mcp, "streamable_http_app", lambda: base_app)
+    monkeypatch.setattr(server.config, "VAULT_PUBLIC_BASE_URL", "https://vault.example")
+    monkeypatch.setattr(server.config, "VAULT_OAUTH_PERSIST_REGISTERED_CLIENTS", True)
+    monkeypatch.setattr(server.config, "VAULT_OAUTH_REGISTERED_CLIENT_STORE_PATH", store_path)
+    monkeypatch.setattr(server.config, "REGISTERED_CLIENT_TTL_SECONDS", 0)
+    monkeypatch.setattr(server.config, "MAX_REGISTERED_CLIENTS", 128)
+
+    app = server.build_app()
+    with TestClient(app) as client:
+        response = client.get("/health")
+
+    body = response.json()
+    assert body["oauth"]["public_base_url_configured"] is True
+    assert body["oauth"]["registered_client_store_path"] == str(store_path)
+    assert body["oauth"]["registered_client_store_exists"] is True
+    assert body["oauth"]["registered_client_ttl_seconds"] == 0
+    assert body["oauth"]["restart_stable_reconnects"] is True
 
 
 def test_build_app_exposes_oauth_discovery_aliases_without_bearer(vault_dir, monkeypatch):

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -41,6 +41,19 @@ def test_vault_read_serializes_yaml_date_frontmatter(vault_dir):
     assert result["frontmatter"]["created"] == "2026-04-05"
 
 
+def test_vault_read_rejects_binary_pdf(vault_dir):
+    """vault_read should return a clear binary-file error for PDFs."""
+    (vault_dir / "sample.pdf").write_bytes(b"%PDF-1.7\n%\xb5\xb5\xb5\xb5\n")
+
+    result = json.loads(vault_read("sample.pdf"))
+
+    assert result["path"] == "sample.pdf"
+    assert result["error"] == (
+        "Binary file type .pdf is not supported by vault_read. "
+        "Use a dedicated binary/PDF reader."
+    )
+
+
 def test_vault_search_frontmatter_excerpt_serializes_datetime(vault_dir):
     """vault_search serializes datetime values found in frontmatter excerpts."""
     post = frontmatter.Post("Searchable content.\n")
@@ -236,6 +249,24 @@ def test_vault_batch_read_handles_missing(vault_dir):
     assert result["found"] == 1
     assert result["missing"] == 1
     assert "error" in result["files"][1]
+
+
+def test_vault_batch_read_reports_binary_pdf_error(vault_dir):
+    """vault_batch_read should report binary-file errors without aborting the batch."""
+    (vault_dir / "sample.pdf").write_bytes(b"%PDF-1.7\n%\xb5\xb5\xb5\xb5\n")
+
+    result = json.loads(vault_batch_read(
+        ["test-note.md", "sample.pdf"],
+        include_content=True,
+    ))
+
+    assert result["found"] == 1
+    assert result["missing"] == 1
+    pdf_entry = next(item for item in result["files"] if item["path"] == "sample.pdf")
+    assert pdf_entry["error"] == (
+        "Binary file type .pdf is not supported by vault_read. "
+        "Use a dedicated binary/PDF reader."
+    )
 
 
 def test_vault_list_returns_items(vault_dir):

--- a/tests/test_vault.py
+++ b/tests/test_vault.py
@@ -57,6 +57,15 @@ def test_read_missing_file(vault_dir):
         read_file("nonexistent.md")
 
 
+def test_read_file_rejects_binary_pdf(vault_dir):
+    """Known binary files should fail with a clear error before UTF-8 decoding."""
+    pdf_file = vault_dir / "sample.pdf"
+    pdf_file.write_bytes(b"%PDF-1.7\n%\xb5\xb5\xb5\xb5\n")
+
+    with pytest.raises(ValueError, match=r"Binary file type \.pdf is not supported"):
+        read_file("sample.pdf")
+
+
 def test_write_atomic_new_file(vault_dir):
     """Write a new file and verify it exists."""
     is_new, size = write_file_atomic("new-file.md", "# Hello\n\nNew content.")


### PR DESCRIPTION
## What changed

This PR fixes the PDF/binary `vault_read` failure path and adds restart-focused OAuth visibility for operators.

- reject known binary file types before attempting UTF-8 text reads
- add regression tests for `read_file`, `vault_read`, and `vault_batch_read`
- expose OAuth restart configuration in `/health`
- log OAuth persistence/runtime status during server startup
- document the restart-safe OAuth checklist in the README and operations runbook

## Why

Two practical issues were causing friction:

1. PDF files were being opened as UTF-8 text, which produced misleading decode errors instead of a clear binary-file response.
2. After server restarts, connector reauthentication was hard to diagnose because the restart-relevant OAuth settings were not surfaced clearly in health output or startup logs.

## Impact

Users now get a clear error for unsupported binary reads instead of a raw UTF-8 decode failure, and operators can quickly verify whether the server is configured for restart-stable OAuth reconnects.

## Validation

- `pytest tests/test_vault.py tests/test_tools.py tests/test_security.py`

## Notes

Vault backlog notes were also added locally outside the repo for:

- direct PDF-reading as a follow-up feature
- restart/re-auth troubleshooting and operator assumptions
