### PR TITLE
[codex] Add chunked binary upload flow

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,6 +93,10 @@ This is a server that provides network access to your personal notes. Security i
 | `vault_analytics_findings` | Return detailed findings for one analytics category such as broken wikilinks or encoding issues, including wikilink classification details |
 | `vault_write` | Write a file with optional frontmatter merging; creates parent dirs |
 | `vault_write_binary` | Write an allowed binary file such as PNG, JPEG, WebP, GIF, SVG, or PDF from base64 input |
+| `vault_write_binary_init` | Initialize a staged chunked binary upload when one base64 payload would be too large for a single tool call |
+| `vault_write_binary_chunk` | Append one base64-encoded chunk to a staged binary upload in strict sequential order |
+| `vault_write_binary_commit` | Verify a staged binary upload with a SHA-256 checksum and atomically commit it into the vault |
+| `vault_write_binary_abort` | Discard a staged chunked binary upload without writing it into the vault |
 | `vault_batch_frontmatter_update` | Update YAML frontmatter fields on multiple files without touching body content |
 | `vault_str_replace` | Replace one exact string in a file without rewriting the whole note body in the request; optional `replace_all=true` supports file-local bulk normalization |
 | `vault_search` | Full-text search across vault files (uses ripgrep when available and falls back to Python when needed) |
@@ -257,6 +261,18 @@ Practical recommendations:
 4. If the connector expects `/authorize` instead of `/oauth/authorize`, this fork already provides the compatibility alias.
 
 In practice, the fixes in this fork around OAuth discovery, forwarded-host handling, `/authorize` compatibility, and date serialization were added specifically to improve real client interoperability, including ChatGPT-style connector flows.
+
+### Chunked Binary Uploads
+
+If a single `vault_write_binary` call would be too large for the agent or connector payload limit, use the staged chunked flow instead:
+
+1. `vault_write_binary_init`
+2. one or more `vault_write_binary_chunk` calls
+3. `vault_write_binary_commit` with the SHA-256 checksum of the full decoded file
+
+If you need to cancel the upload, call `vault_write_binary_abort`.
+
+Chunked uploads are staged under the server cache directory and only become visible in the vault after a successful commit.
 
 ## Remote Access with Cloudflare Tunnel
 

--- a/src/obsidian_vault_mcp/models.py
+++ b/src/obsidian_vault_mcp/models.py
@@ -94,6 +94,107 @@ class VaultWriteBinaryInput(BaseModel):
     )
 
 
+class VaultWriteBinaryInitInput(BaseModel):
+    """Initialize a staged chunked binary upload."""
+
+    model_config = ConfigDict(str_strip_whitespace=True, extra="forbid")
+
+    path: str = Field(
+        ...,
+        description="Relative path from vault root including filename and extension",
+        min_length=1,
+        max_length=500,
+    )
+    media_type: Literal[
+        "image/png",
+        "image/jpeg",
+        "image/webp",
+        "image/gif",
+        "image/svg+xml",
+        "application/pdf",
+    ] = Field(
+        ...,
+        description="MIME type of the binary content",
+    )
+    total_size: int = Field(
+        ...,
+        ge=1,
+        le=MAX_BINARY_SIZE,
+        description="Total decoded file size in bytes expected across all chunks",
+    )
+    overwrite: bool = Field(
+        default=False,
+        description="If true, allow replacing an existing file at commit time",
+    )
+    create_dirs: bool = Field(
+        default=True,
+        description="Create parent directories if they don't exist when the upload is committed",
+    )
+
+
+class VaultWriteBinaryChunkInput(BaseModel):
+    """Append one chunk to a staged chunked binary upload."""
+
+    model_config = ConfigDict(str_strip_whitespace=True, extra="forbid")
+
+    upload_id: str = Field(
+        ...,
+        description="Upload session identifier returned by vault_write_binary_init",
+        min_length=8,
+        max_length=100,
+    )
+    chunk_index: int = Field(
+        ...,
+        ge=0,
+        description="Zero-based sequential chunk number; must match the next expected index",
+    )
+    data: str = Field(
+        ...,
+        description="Base64-encoded binary chunk payload",
+        min_length=1,
+        max_length=((256 * 1024 + 2) // 3) * 4 + 1024,
+    )
+
+
+class VaultWriteBinaryCommitInput(BaseModel):
+    """Finalize a staged chunked binary upload."""
+
+    model_config = ConfigDict(str_strip_whitespace=True, extra="forbid")
+
+    upload_id: str = Field(
+        ...,
+        description="Upload session identifier returned by vault_write_binary_init",
+        min_length=8,
+        max_length=100,
+    )
+    expected_checksum: str = Field(
+        ...,
+        description="SHA-256 checksum of the full decoded file, hex encoded",
+        min_length=64,
+        max_length=64,
+    )
+
+    @field_validator("expected_checksum")
+    @classmethod
+    def validate_expected_checksum(cls, v: str) -> str:
+        if any(ch not in "0123456789abcdefABCDEF" for ch in v):
+            raise ValueError("expected_checksum must be a 64-character hex SHA-256 digest")
+        return v.lower()
+
+
+class VaultWriteBinaryAbortInput(BaseModel):
+    """Abort a staged chunked binary upload."""
+
+    model_config = ConfigDict(str_strip_whitespace=True, extra="forbid")
+
+    upload_id: str = Field(
+        ...,
+        description="Upload session identifier returned by vault_write_binary_init",
+        min_length=8,
+        max_length=100,
+    )
+
+
 class VaultStrReplaceInput(BaseModel):
     """Replace exactly one unique string in an existing file."""
 

--- a/src/obsidian_vault_mcp/server.py
+++ b/src/obsidian_vault_mcp/server.py
@@ -277,6 +277,10 @@ from .tools.analytics import (
 )
 from .tools.write import (
     vault_batch_frontmatter_update as _vault_batch_frontmatter_update,
+    vault_write_binary_abort as _vault_write_binary_abort,
+    vault_write_binary_chunk as _vault_write_binary_chunk,
+    vault_write_binary_commit as _vault_write_binary_commit,
+    vault_write_binary_init as _vault_write_binary_init,
     vault_str_replace as _vault_str_replace,
     vault_write as _vault_write,
     vault_write_binary as _vault_write_binary,
@@ -300,7 +304,11 @@ from .models import (
     VaultReadInput,
     VaultStrReplaceInput,
     VaultWriteInput,
+    VaultWriteBinaryAbortInput,
     VaultWriteBinaryInput,
+    VaultWriteBinaryChunkInput,
+    VaultWriteBinaryCommitInput,
+    VaultWriteBinaryInitInput,
     VaultBatchReadInput,
     VaultBatchFrontmatterUpdateInput,
     VaultSearchInput,
@@ -466,6 +474,96 @@ def vault_write_binary(
         overwrite=inp.overwrite,
         create_dirs=inp.create_dirs,
         base64_bytes=len(inp.data),
+    )
+
+
+@mcp.tool(
+    name="vault_write_binary_init",
+    description="Initialize a chunked binary upload into the Obsidian vault. Use this when one base64 payload would be too large for a single tool call.",
+    annotations={"readOnlyHint": False, "destructiveHint": True, "idempotentHint": False, "openWorldHint": False},
+)
+def vault_write_binary_init(
+    path: str,
+    media_type: str,
+    total_size: int,
+    overwrite: bool = False,
+    create_dirs: bool = True,
+) -> str:
+    """Initialize a staged binary upload."""
+    inp = VaultWriteBinaryInitInput(
+        path=path,
+        media_type=media_type,
+        total_size=total_size,
+        overwrite=overwrite,
+        create_dirs=create_dirs,
+    )
+    limited = _tool_rate_limit_error("write", config.RATE_LIMIT_WRITE)
+    if limited is not None:
+        return limited
+    return _run_logged_tool(
+        "vault_write_binary_init",
+        lambda: _vault_write_binary_init(inp.path, inp.media_type, inp.total_size, inp.overwrite, inp.create_dirs),
+        path=inp.path,
+        media_type=inp.media_type,
+        total_size=inp.total_size,
+        overwrite=inp.overwrite,
+        create_dirs=inp.create_dirs,
+    )
+
+
+@mcp.tool(
+    name="vault_write_binary_chunk",
+    description="Append one base64-encoded chunk to a staged binary upload. Chunks must be sent in strict ascending order starting at chunk_index=0.",
+    annotations={"readOnlyHint": False, "destructiveHint": True, "idempotentHint": False, "openWorldHint": False},
+)
+def vault_write_binary_chunk(upload_id: str, chunk_index: int, data: str) -> str:
+    """Append one chunk to a staged binary upload."""
+    inp = VaultWriteBinaryChunkInput(upload_id=upload_id, chunk_index=chunk_index, data=data)
+    limited = _tool_rate_limit_error("write", config.RATE_LIMIT_WRITE)
+    if limited is not None:
+        return limited
+    return _run_logged_tool(
+        "vault_write_binary_chunk",
+        lambda: _vault_write_binary_chunk(inp.upload_id, inp.chunk_index, inp.data),
+        upload_id=inp.upload_id,
+        chunk_index=inp.chunk_index,
+        base64_bytes=len(inp.data),
+    )
+
+
+@mcp.tool(
+    name="vault_write_binary_commit",
+    description="Verify and commit a staged chunked binary upload into the vault using a SHA-256 checksum over the full decoded file.",
+    annotations={"readOnlyHint": False, "destructiveHint": True, "idempotentHint": False, "openWorldHint": False},
+)
+def vault_write_binary_commit(upload_id: str, expected_checksum: str) -> str:
+    """Commit a staged binary upload."""
+    inp = VaultWriteBinaryCommitInput(upload_id=upload_id, expected_checksum=expected_checksum)
+    limited = _tool_rate_limit_error("write", config.RATE_LIMIT_WRITE)
+    if limited is not None:
+        return limited
+    return _run_logged_tool(
+        "vault_write_binary_commit",
+        lambda: _vault_write_binary_commit(inp.upload_id, inp.expected_checksum),
+        upload_id=inp.upload_id,
+    )
+
+
+@mcp.tool(
+    name="vault_write_binary_abort",
+    description="Abort and discard a staged chunked binary upload.",
+    annotations={"readOnlyHint": False, "destructiveHint": True, "idempotentHint": False, "openWorldHint": False},
+)
+def vault_write_binary_abort(upload_id: str) -> str:
+    """Abort a staged binary upload."""
+    inp = VaultWriteBinaryAbortInput(upload_id=upload_id)
+    limited = _tool_rate_limit_error("write", config.RATE_LIMIT_WRITE)
+    if limited is not None:
+        return limited
+    return _run_logged_tool(
+        "vault_write_binary_abort",
+        lambda: _vault_write_binary_abort(inp.upload_id),
+        upload_id=inp.upload_id,
     )
 
 

--- a/src/obsidian_vault_mcp/tools/write.py
+++ b/src/obsidian_vault_mcp/tools/write.py
@@ -2,11 +2,18 @@
 
 import base64
 import binascii
+import hashlib
+import json
 import logging
+import os
+import secrets
+import shutil
+import time
 from pathlib import Path
 
 import frontmatter
 
+from .. import config
 from ..vault import (
     read_file,
     resolve_vault_path,
@@ -25,6 +32,92 @@ ALLOWED_BINARY_MEDIA_TYPES = {
     "image/svg+xml": {".svg"},
     "application/pdf": {".pdf"},
 }
+
+MAX_BINARY_CHUNK_SIZE = 256 * 1024
+UPLOAD_STAGING_DIRNAME = "upload-staging"
+UPLOAD_EXPIRY_SECONDS = 15 * 60
+
+
+def _allowed_binary_extensions_for(media_type: str) -> set[str] | None:
+    """Return the allowed file extensions for one binary media type."""
+    return ALLOWED_BINARY_MEDIA_TYPES.get(media_type)
+
+
+def _binary_upload_root() -> Path:
+    """Return the on-disk staging root for chunked binary uploads."""
+    root = config.SEMANTIC_CACHE_PATH / UPLOAD_STAGING_DIRNAME
+    root.mkdir(parents=True, exist_ok=True)
+    return root
+
+
+def _write_json_atomic(path: Path, payload: dict) -> None:
+    """Persist JSON metadata atomically in the staging directory."""
+    tmp_path = path.with_suffix(f"{path.suffix}.tmp")
+    tmp_path.write_text(json.dumps(payload, ensure_ascii=True, indent=2), encoding="utf-8")
+    tmp_path.replace(path)
+
+
+def _upload_paths(upload_id: str) -> tuple[Path, Path, Path]:
+    """Return the staging directory and metadata/content file paths for one upload."""
+    upload_dir = _binary_upload_root() / upload_id
+    metadata_path = upload_dir / "metadata.json"
+    content_path = upload_dir / "payload.bin"
+    return upload_dir, metadata_path, content_path
+
+
+def _cleanup_stale_binary_uploads() -> None:
+    """Remove abandoned staged uploads after a short inactivity window."""
+    root = _binary_upload_root()
+    cutoff = time.time() - UPLOAD_EXPIRY_SECONDS
+    for entry in root.iterdir():
+        if not entry.is_dir():
+            continue
+        try:
+            if entry.stat().st_mtime < cutoff:
+                shutil.rmtree(entry)
+        except OSError:
+            logger.warning("Could not remove stale binary upload staging dir: %s", entry)
+
+
+def _load_upload_metadata(upload_id: str) -> tuple[dict, Path, Path, Path]:
+    """Load staged upload metadata and return it with the associated file paths."""
+    upload_dir, metadata_path, content_path = _upload_paths(upload_id)
+    if not upload_dir.exists() or not metadata_path.exists():
+        raise ValueError(f"Unknown upload_id: {upload_id}")
+    try:
+        metadata = json.loads(metadata_path.read_text(encoding="utf-8"))
+    except Exception as exc:  # pragma: no cover - corrupted staging should be rare
+        raise ValueError(f"Failed to read upload metadata for {upload_id}: {exc}") from exc
+    return metadata, upload_dir, metadata_path, content_path
+
+
+def _validate_binary_target(path: str, media_type: str) -> tuple[Path, str]:
+    """Validate the target path and media type for binary write flows."""
+    resolved = resolve_vault_path(path)
+    extension = Path(path).suffix.lower()
+    allowed_extensions = _allowed_binary_extensions_for(media_type)
+    if not allowed_extensions:
+        raise ValueError(f"Unsupported media_type: {media_type}")
+    if extension not in allowed_extensions:
+        raise ValueError(f"Extension '{extension}' is not allowed for media_type '{media_type}'")
+    return resolved, extension
+
+
+def _decode_base64_chunk(data: str) -> bytes:
+    """Decode a base64 payload chunk with strict validation."""
+    try:
+        return base64.b64decode(data, validate=True)
+    except (binascii.Error, ValueError) as exc:
+        raise ValueError("Invalid base64 data") from exc
+
+
+def _sha256_file(path: Path) -> str:
+    """Return the SHA-256 checksum of one staged upload file."""
+    digest = hashlib.sha256()
+    with path.open("rb") as handle:
+        for chunk in iter(lambda: handle.read(1024 * 1024), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
 
 
 def vault_write(path: str, content: str, create_dirs: bool = True, merge_frontmatter: bool = False) -> str:
@@ -96,23 +189,11 @@ def vault_write_binary(
 ) -> str:
     """Write an allowed binary file to the vault from base64-encoded content."""
     try:
-        resolved = resolve_vault_path(path)
-        extension = Path(path).suffix.lower()
-        allowed_extensions = ALLOWED_BINARY_MEDIA_TYPES.get(media_type)
-        if not allowed_extensions:
-            return vault_json_dumps({"error": f"Unsupported media_type: {media_type}", "path": path, "media_type": media_type})
-        if extension not in allowed_extensions:
-            return vault_json_dumps(
-                {
-                    "error": f"Extension '{extension}' is not allowed for media_type '{media_type}'",
-                    "path": path,
-                    "media_type": media_type,
-                }
-            )
+        resolved, _extension = _validate_binary_target(path, media_type)
 
         try:
-            decoded = base64.b64decode(data, validate=True)
-        except (binascii.Error, ValueError):
+            decoded = _decode_base64_chunk(data)
+        except ValueError:
             return vault_json_dumps({"error": "Invalid base64 data", "path": path, "media_type": media_type})
 
         if resolved.exists() and not overwrite:
@@ -138,6 +219,207 @@ def vault_write_binary(
     except Exception as e:
         logger.error(f"vault_write_binary error for {path}: {e}")
         return vault_json_dumps({"error": str(e), "path": path, "media_type": media_type})
+
+
+def vault_write_binary_init(
+    path: str,
+    media_type: str,
+    total_size: int,
+    overwrite: bool = False,
+    create_dirs: bool = True,
+) -> str:
+    """Initialize a staged chunked binary upload."""
+    try:
+        _cleanup_stale_binary_uploads()
+        resolved, _extension = _validate_binary_target(path, media_type)
+
+        if total_size <= 0:
+            return vault_json_dumps({"error": "total_size must be greater than 0", "path": path, "media_type": media_type})
+        if total_size > config.MAX_BINARY_SIZE:
+            return vault_json_dumps(
+                {
+                    "error": f"Content size {total_size} bytes exceeds limit of {config.MAX_BINARY_SIZE} bytes",
+                    "path": path,
+                    "media_type": media_type,
+                }
+            )
+        if resolved.exists() and not overwrite:
+            return vault_json_dumps(
+                {
+                    "error": f"File already exists: {path}. Set overwrite=true to replace it.",
+                    "path": path,
+                    "media_type": media_type,
+                }
+            )
+
+        upload_id = secrets.token_hex(12)
+        upload_dir, metadata_path, content_path = _upload_paths(upload_id)
+        upload_dir.mkdir(parents=True, exist_ok=False)
+        content_path.write_bytes(b"")
+        metadata = {
+            "upload_id": upload_id,
+            "path": path,
+            "media_type": media_type,
+            "total_size": total_size,
+            "overwrite": overwrite,
+            "create_dirs": create_dirs,
+            "bytes_received": 0,
+            "next_expected_index": 0,
+            "created_at": time.time(),
+            "updated_at": time.time(),
+        }
+        _write_json_atomic(metadata_path, metadata)
+
+        return vault_json_dumps(
+            {
+                "upload_id": upload_id,
+                "path": path,
+                "media_type": media_type,
+                "total_size": total_size,
+                "max_chunk_size": MAX_BINARY_CHUNK_SIZE,
+                "expires_in_seconds": UPLOAD_EXPIRY_SECONDS,
+            }
+        )
+    except ValueError as e:
+        return vault_json_dumps({"error": str(e), "path": path, "media_type": media_type})
+    except Exception as e:
+        logger.error(f"vault_write_binary_init error for {path}: {e}")
+        return vault_json_dumps({"error": str(e), "path": path, "media_type": media_type})
+
+
+def vault_write_binary_chunk(upload_id: str, chunk_index: int, data: str) -> str:
+    """Append one base64-decoded chunk to an initialized staged binary upload."""
+    try:
+        _cleanup_stale_binary_uploads()
+        metadata, _upload_dir, metadata_path, content_path = _load_upload_metadata(upload_id)
+
+        if chunk_index != metadata["next_expected_index"]:
+            return vault_json_dumps(
+                {
+                    "error": f"Unexpected chunk_index {chunk_index}; expected {metadata['next_expected_index']}",
+                    "upload_id": upload_id,
+                    "next_expected_index": metadata["next_expected_index"],
+                }
+            )
+
+        decoded = _decode_base64_chunk(data)
+        if len(decoded) > MAX_BINARY_CHUNK_SIZE:
+            return vault_json_dumps(
+                {
+                    "error": f"Chunk size {len(decoded)} bytes exceeds limit of {MAX_BINARY_CHUNK_SIZE} bytes",
+                    "upload_id": upload_id,
+                }
+            )
+        next_size = metadata["bytes_received"] + len(decoded)
+        if next_size > metadata["total_size"]:
+            return vault_json_dumps(
+                {
+                    "error": f"Chunk would exceed declared total_size {metadata['total_size']} bytes",
+                    "upload_id": upload_id,
+                }
+            )
+
+        with content_path.open("ab") as handle:
+            handle.write(decoded)
+
+        metadata["bytes_received"] = next_size
+        metadata["next_expected_index"] += 1
+        metadata["updated_at"] = time.time()
+        _write_json_atomic(metadata_path, metadata)
+
+        return vault_json_dumps(
+            {
+                "upload_id": upload_id,
+                "received_bytes": metadata["bytes_received"],
+                "next_expected_index": metadata["next_expected_index"],
+                "total_size": metadata["total_size"],
+                "complete": metadata["bytes_received"] == metadata["total_size"],
+            }
+        )
+    except ValueError as e:
+        return vault_json_dumps({"error": str(e), "upload_id": upload_id})
+    except Exception as e:
+        logger.error(f"vault_write_binary_chunk error for {upload_id}: {e}")
+        return vault_json_dumps({"error": str(e), "upload_id": upload_id})
+
+
+def vault_write_binary_commit(upload_id: str, expected_checksum: str) -> str:
+    """Verify and atomically commit a staged chunked binary upload into the vault."""
+    try:
+        _cleanup_stale_binary_uploads()
+        metadata, upload_dir, _metadata_path, content_path = _load_upload_metadata(upload_id)
+        path = metadata["path"]
+        media_type = metadata["media_type"]
+
+        if len(expected_checksum) != 64 or any(ch not in "0123456789abcdefABCDEF" for ch in expected_checksum):
+            return vault_json_dumps({"error": "expected_checksum must be a 64-character hex SHA-256 digest", "upload_id": upload_id})
+        if metadata["bytes_received"] != metadata["total_size"]:
+            return vault_json_dumps(
+                {
+                    "error": f"Upload incomplete: received {metadata['bytes_received']} of {metadata['total_size']} bytes",
+                    "upload_id": upload_id,
+                    "received_bytes": metadata["bytes_received"],
+                    "total_size": metadata["total_size"],
+                }
+            )
+
+        resolved, _extension = _validate_binary_target(path, media_type)
+        actual_checksum = _sha256_file(content_path)
+        if actual_checksum.lower() != expected_checksum.lower():
+            return vault_json_dumps(
+                {
+                    "error": "Checksum mismatch",
+                    "upload_id": upload_id,
+                    "expected_checksum": expected_checksum.lower(),
+                    "actual_checksum": actual_checksum,
+                }
+            )
+
+        is_new = not resolved.exists()
+        if resolved.exists() and not metadata["overwrite"]:
+            return vault_json_dumps(
+                {
+                    "error": f"File already exists: {path}. Set overwrite=true to replace it.",
+                    "upload_id": upload_id,
+                    "path": path,
+                }
+            )
+
+        if metadata["create_dirs"]:
+            resolved.parent.mkdir(parents=True, exist_ok=True)
+
+        os.replace(content_path, resolved)
+        shutil.rmtree(upload_dir)
+
+        return vault_json_dumps(
+            {
+                "upload_id": upload_id,
+                "path": path,
+                "created": is_new,
+                "size": metadata["total_size"],
+                "media_type": media_type,
+                "checksum": actual_checksum,
+            }
+        )
+    except ValueError as e:
+        return vault_json_dumps({"error": str(e), "upload_id": upload_id})
+    except Exception as e:
+        logger.error(f"vault_write_binary_commit error for {upload_id}: {e}")
+        return vault_json_dumps({"error": str(e), "upload_id": upload_id})
+
+
+def vault_write_binary_abort(upload_id: str) -> str:
+    """Abort and discard a staged chunked binary upload."""
+    try:
+        metadata, upload_dir, _metadata_path, _content_path = _load_upload_metadata(upload_id)
+        path = metadata["path"]
+        shutil.rmtree(upload_dir)
+        return vault_json_dumps({"upload_id": upload_id, "path": path, "aborted": True})
+    except ValueError as e:
+        return vault_json_dumps({"error": str(e), "upload_id": upload_id})
+    except Exception as e:
+        logger.error(f"vault_write_binary_abort error for {upload_id}: {e}")
+        return vault_json_dumps({"error": str(e), "upload_id": upload_id})
 
 
 def vault_str_replace(path: str, old_str: str, new_str: str = "", replace_all: bool = False) -> str:

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -1,6 +1,7 @@
 """Integration tests for tool functions."""
 
 import base64
+import hashlib
 import json
 import os
 from datetime import date, datetime
@@ -8,11 +9,16 @@ from datetime import date, datetime
 import pytest
 import frontmatter
 
+from obsidian_vault_mcp import config
 from obsidian_vault_mcp.tools.read import vault_read, vault_batch_read
 from obsidian_vault_mcp.tools.write import (
     vault_batch_frontmatter_update,
     vault_str_replace,
     vault_write,
+    vault_write_binary_abort,
+    vault_write_binary_chunk,
+    vault_write_binary_commit,
+    vault_write_binary_init,
     vault_write_binary,
 )
 from obsidian_vault_mcp.tools.analytics import vault_analytics_findings, vault_analytics_summary
@@ -135,6 +141,80 @@ def test_vault_write_binary_requires_overwrite_opt_in(vault_dir):
     assert "error" in result
     assert "overwrite=true" in result["error"]
     assert (vault_dir / "assets" / "visual.png").read_bytes() == b"old"
+
+
+def test_vault_write_binary_chunked_commit_creates_pdf(vault_dir, monkeypatch):
+    """Chunked binary upload should stage, verify, and commit a file successfully."""
+    monkeypatch.setattr(config, "SEMANTIC_CACHE_PATH", vault_dir / ".obsidian-vault-mcp")
+    pdf_bytes = b"%PDF-1.7\n%chunked\nbody"
+
+    init_result = json.loads(
+        vault_write_binary_init(
+            "assets/chunked.pdf",
+            "application/pdf",
+            len(pdf_bytes),
+        )
+    )
+    assert "error" not in init_result
+
+    upload_id = init_result["upload_id"]
+    chunk_a = json.loads(vault_write_binary_chunk(upload_id, 0, base64.b64encode(pdf_bytes[:8]).decode("ascii")))
+    chunk_b = json.loads(vault_write_binary_chunk(upload_id, 1, base64.b64encode(pdf_bytes[8:]).decode("ascii")))
+    commit_result = json.loads(
+        vault_write_binary_commit(
+            upload_id,
+            hashlib.sha256(pdf_bytes).hexdigest(),
+        )
+    )
+
+    assert chunk_a["received_bytes"] == 8
+    assert chunk_b["complete"] is True
+    assert commit_result["created"] is True
+    assert commit_result["size"] == len(pdf_bytes)
+    assert (vault_dir / "assets" / "chunked.pdf").read_bytes() == pdf_bytes
+    assert not ((vault_dir / ".obsidian-vault-mcp" / "upload-staging" / upload_id).exists())
+
+
+def test_vault_write_binary_chunked_rejects_out_of_order_chunk(vault_dir, monkeypatch):
+    """Chunked binary upload should enforce strictly increasing chunk indexes."""
+    monkeypatch.setattr(config, "SEMANTIC_CACHE_PATH", vault_dir / ".obsidian-vault-mcp")
+    payload = b"abcdef"
+
+    init_result = json.loads(vault_write_binary_init("assets/out-of-order.pdf", "application/pdf", len(payload)))
+    upload_id = init_result["upload_id"]
+    result = json.loads(vault_write_binary_chunk(upload_id, 1, base64.b64encode(payload).decode("ascii")))
+
+    assert "error" in result
+    assert "expected 0" in result["error"]
+
+
+def test_vault_write_binary_chunked_detects_checksum_mismatch(vault_dir, monkeypatch):
+    """Commit should fail if the provided checksum does not match the staged bytes."""
+    monkeypatch.setattr(config, "SEMANTIC_CACHE_PATH", vault_dir / ".obsidian-vault-mcp")
+    payload = b"checksum-test"
+
+    init_result = json.loads(vault_write_binary_init("assets/checksum.pdf", "application/pdf", len(payload)))
+    upload_id = init_result["upload_id"]
+    json.loads(vault_write_binary_chunk(upload_id, 0, base64.b64encode(payload).decode("ascii")))
+    commit_result = json.loads(vault_write_binary_commit(upload_id, "0" * 64))
+
+    assert commit_result["error"] == "Checksum mismatch"
+    assert commit_result["actual_checksum"] == hashlib.sha256(payload).hexdigest()
+    assert not (vault_dir / "assets" / "checksum.pdf").exists()
+
+
+def test_vault_write_binary_chunked_abort_discards_staged_upload(vault_dir, monkeypatch):
+    """Abort should remove staged chunk data and metadata."""
+    monkeypatch.setattr(config, "SEMANTIC_CACHE_PATH", vault_dir / ".obsidian-vault-mcp")
+    payload = b"abort-me"
+
+    init_result = json.loads(vault_write_binary_init("assets/abort.pdf", "application/pdf", len(payload)))
+    upload_id = init_result["upload_id"]
+    json.loads(vault_write_binary_chunk(upload_id, 0, base64.b64encode(payload).decode("ascii")))
+    abort_result = json.loads(vault_write_binary_abort(upload_id))
+
+    assert abort_result["aborted"] is True
+    assert not ((vault_dir / ".obsidian-vault-mcp" / "upload-staging" / upload_id).exists())
 
 
 def test_vault_str_replace_updates_unique_match(vault_dir):


### PR DESCRIPTION
## What changed

This PR adds a staged chunked binary upload flow for files that are too large for a single `vault_write_binary` tool call.

- add `vault_write_binary_init`
- add `vault_write_binary_chunk`
- add `vault_write_binary_commit`
- add `vault_write_binary_abort`
- stage uploads under `.obsidian-vault-mcp/upload-staging`
- enforce sequential chunk indexes and SHA-256 verification on commit
- document the chunked upload flow in the README
- add tool tests for success, ordering errors, checksum mismatch, and abort cleanup

## Why

`vault_write_binary` works for normal payloads, but larger base64 payloads run into agent or connector request-size limits before they reliably reach the server. This staged flow keeps the existing binary-write safety model while making larger uploads practical.

## Validation

- `pytest tests/test_tools.py tests/test_vault.py tests/test_security.py`
- `python -m compileall src`
