### PR TITLE
fix: restore vault_str_replace schema

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ This project follows semantic versioning. Release dates use YYYY-MM-DD.
 
 ## [Unreleased]
 
+## [v0.7.1] - 2026-05-24
+
+### Fixed
+- Restore the public `vault_str_replace` MCP contract to `path`, `old_string`, `new_string`, and `replace_all`, matching existing Claude and ChatGPT clients.
+- Add regression coverage for documented `vault_str_replace` keyword calls and schema discovery.
+
 ## [v0.7.0] - 2026-05-15
 
 ### BREAKING CHANGES

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "obsidian-web-mcp"
-version = "0.7.0"
+version = "0.7.1"
 description = "Secure remote MCP server for Obsidian vaults -- access your notes from Claude, your phone, or any MCP client, anywhere"
 readme = "README.md"
 requires-python = ">=3.12"

--- a/src/obsidian_vault_mcp/models.py
+++ b/src/obsidian_vault_mcp/models.py
@@ -141,20 +141,20 @@ class VaultStrReplaceInput(BaseModel):
         min_length=1,
         max_length=500,
     )
-    old_str: str = Field(
+    old_string: str = Field(
         ...,
         description="Exact string to replace; must occur exactly once",
         min_length=1,
         max_length=MAX_CONTENT_SIZE,
     )
-    new_str: str = Field(
+    new_string: str = Field(
         default="",
         description="Replacement string; empty string deletes the matched text",
         max_length=MAX_CONTENT_SIZE,
     )
     replace_all: bool = Field(
         default=False,
-        description="If true, replace every occurrence of old_str instead of requiring a unique match",
+        description="If true, replace every occurrence of old_string instead of requiring a unique match",
     )
 
 

--- a/src/obsidian_vault_mcp/server.py
+++ b/src/obsidian_vault_mcp/server.py
@@ -906,21 +906,21 @@ def vault_batch_replace(updates: list[dict]) -> str:
 
 @mcp.tool(
     name="vault_str_replace",
-    description="Replace one exact string in a vault file. By default old_str must be unique; set replace_all=true to replace every occurrence.",
+    description="Replace one exact string in a vault file. By default old_string must be unique; set replace_all=true to replace every occurrence.",
     annotations={"readOnlyHint": False, "destructiveHint": True, "idempotentHint": False, "openWorldHint": False},
 )
-def vault_str_replace(path: str, old_str: str, new_str: str = "", replace_all: bool = False) -> str:
+def vault_str_replace(path: str, old_string: str, new_string: str = "", replace_all: bool = False) -> str:
     """Replace an exact string in a vault file."""
-    inp = VaultStrReplaceInput(path=path, old_str=old_str, new_str=new_str, replace_all=replace_all)
+    inp = VaultStrReplaceInput(path=path, old_string=old_string, new_string=new_string, replace_all=replace_all)
     limited = _tool_rate_limit_error("write", config.RATE_LIMIT_WRITE)
     if limited is not None:
         return limited
     return _run_logged_tool(
         "vault_str_replace",
-        lambda: _vault_str_replace(inp.path, inp.old_str, inp.new_str, inp.replace_all),
+        lambda: _vault_str_replace(inp.path, inp.old_string, inp.new_string, inp.replace_all),
         path=inp.path,
-        old_str_bytes=len(inp.old_str.encode("utf-8")),
-        new_str_bytes=len(inp.new_str.encode("utf-8")),
+        old_string_bytes=len(inp.old_string.encode("utf-8")),
+        new_string_bytes=len(inp.new_string.encode("utf-8")),
         replace_all=inp.replace_all,
     )
 

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -282,6 +282,19 @@ def test_daily_note_tool_schemas_are_discoverable():
     assert "VAULT_DAILY_NOTES_TEMPLATE" in schema["properties"]["content"]["description"]
 
 
+def test_vault_str_replace_tool_schema_uses_documented_parameters():
+    """vault_str_replace should expose the stable old_string/new_string contract."""
+    from obsidian_vault_mcp.server import mcp
+
+    tool = mcp._tool_manager.get_tool("vault_str_replace")
+    schema = tool.parameters
+
+    assert "old_string" in schema["properties"]
+    assert "new_string" in schema["properties"]
+    assert "old_str" not in schema["properties"]
+    assert "new_str" not in schema["properties"]
+
+
 def test_vault_write_creates_file(vault_dir):
     """vault_write creates a new file."""
     result = json.loads(vault_write("tools-test.md", "---\ntitle: Test\n---\n\nContent."))
@@ -853,6 +866,23 @@ def test_vault_str_replace_updates_unique_match(vault_dir):
     assert "error" not in result
     assert result["replaced"] is True
     assert result["occurrences_found"] == 1
+    assert "updated note" in (vault_dir / "test-note.md").read_text(encoding="utf-8")
+
+
+def test_server_vault_str_replace_accepts_documented_parameter_names(vault_dir):
+    """The MCP server wrapper accepts old_string/new_string keyword calls."""
+    with _authenticated_tool_context():
+        result = json.loads(
+            server.vault_str_replace(
+                path="test-note.md",
+                old_string="test note",
+                new_string="updated note",
+            )
+        )
+
+    assert "error" not in result
+    assert result["path"] == "test-note.md"
+    assert result["replaced"] is True
     assert "updated note" in (vault_dir / "test-note.md").read_text(encoding="utf-8")
 
 


### PR DESCRIPTION
## What changed

- Restores the public `vault_str_replace` MCP contract to `path`, `old_string`, `new_string`, and `replace_all`.
- Keeps the internal replace implementation unchanged while aligning `VaultStrReplaceInput` and the server wrapper with the documented client-facing parameter names.
- Adds regression coverage for MCP schema discovery and a writing server call using `old_string` / `new_string`.
- Bumps the package version and changelog to `v0.7.1`.

## Why

The released server expected `old_str` / `new_str` while established Claude and ChatGPT client calls use `old_string` / `new_string`, causing regular `vault_str_replace` calls to fail validation.

## Validation

- `python -m pytest tests/test_tools.py -k "vault_str_replace or tool_schema_uses_documented_parameters"`
- `python -m pytest`

Vault smoke note: `90_Tools/Obsidian-MCP/20_Bugs-Ideen/Smoke-vault_str_replace-Schema-v0.7.1.md`