### PR TITLE
feat(recurring): canonical schema with backward-compat aliases (v0.8.2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,22 @@ This project follows semantic versioning. Release dates use YYYY-MM-DD.
 
 ## [Unreleased]
 
+## [v0.8.2] - 2026-05-31
+
+### Changed
+- **Canonical template schema aligned with Tasks-Schema v0.7+**:
+  - `target_folder` (formerly `instance_folder`) is the canonical key for the instance directory. `instance_folder` is kept as a legacy alias and emits a warning when used.
+  - `frontmatter_to_inherit` accepts the dict form `{key: value}` (canonical, DRY: values live once in the inheritance map). The previous list form `[key1, key2]` (which read values from top-level template frontmatter) remains as a legacy alias and emits a warning when used.
+  - When both canonical and legacy keys are present on the same template, the canonical form wins and a warning is recorded.
+- Tool response now includes a `warnings` field aggregating per-template schema-shape advisories so misconfiguration surfaces in the response rather than failing silently. Empty inheritance configuration that resolves to zero fields also produces a warning.
+
+### Docs
+- `docs/recurring.md` updated to use the canonical schema in the worked example and to document the alias / conflict / silent-failure-prevention behavior.
+
+### Tests
+- 5 new test cases covering: `instance_folder` legacy alias warning; `target_folder` precedence when both keys are set; `frontmatter_to_inherit` list form warning; list form with no matching keys → "nothing inherited" warning; invalid type (string) → type warning.
+- All 46 recurring test cases green (277 total in the full suite).
+
 ## [v0.8.1] - 2026-05-31
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Production-hardened fork of [`jimprosser/obsidian-web-mcp`](https://github.com/jimprosser/obsidian-web-mcp): an HTTP-based MCP server that exposes an Obsidian vault to LLM clients such as Claude, ChatGPT, and Codex over OAuth 2.0.
 
-**Latest release:** [v0.8.1](https://github.com/mleitnercom/obsidian-web-mcp/releases/tag/v0.8.1) (2026-05-31)
+**Latest release:** [v0.8.2](https://github.com/mleitnercom/obsidian-web-mcp/releases/tag/v0.8.2) (2026-05-31)
 
 ## At a Glance
 

--- a/docs/recurring.md
+++ b/docs/recurring.md
@@ -47,21 +47,38 @@ recurrence_anchor: quarter_end_plus_3d   # required for 'absolute'
 # recurrence_interval: 7d        # required for 'relative' ('Nd' days, 'Nm' months)
 due_offset_days: 0               # added to trigger date to compute the instance 'due'
 priority_initial: 2              # written into instance frontmatter as 'priority'
-instance_folder: 15_Tasks/pbs    # vault-relative folder for instances; defaults to the template's parent
+target_folder: 15_Tasks/pbs      # vault-relative folder for instances; defaults to the template's parent
 instance_title: "Q-Report {period}"  # optional; {template_id}, {period}, {trigger} are interpolated
-frontmatter_to_inherit:          # keys copied verbatim from template to instance
-  - scope
-  - project
+frontmatter_to_inherit:          # canonical: map of fields copied verbatim onto the instance
+  scope: pbs
+  project: governance
 tags_to_inherit:                 # appended to ['recurring-instance']
   - quarterly
   - reporting
-scope: pbs
-project: governance
 # last_run is managed by the tool; do not edit by hand
 ---
 
 # Optional body content
 ```
+
+### Schema aliases (legacy compatibility)
+
+Two keys accept a legacy form. The canonical form is preferred; the alias
+emits a deprecation warning surfaced in the tool's `warnings` field but
+still works:
+
+| Canonical (since v0.8.2) | Legacy alias | Behavior on conflict |
+|---|---|---|
+| `target_folder: 15_Tasks/pbs` | `instance_folder: 15_Tasks/pbs` | If both set, `target_folder` wins + warning. |
+| `frontmatter_to_inherit:`<br>`  scope: pbs`<br>`  project: governance` | `frontmatter_to_inherit:`<br>`  - scope`<br>`  - project`<br>(values read from template's top-level frontmatter) | Dict form wins when both forms are usable. |
+
+The dict form for `frontmatter_to_inherit` is DRY: values live once in the
+inheritance map, not duplicated as top-level template frontmatter. The list
+form remains available for templates predating v0.8.2.
+
+If `frontmatter_to_inherit` is configured but resolves to no fields (e.g. all
+listed keys are typos in the legacy form), the tool emits a warning rather
+than silently producing an empty inheritance.
 
 ### Absolute anchors
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "obsidian-web-mcp"
-version = "0.8.1"
+version = "0.8.2"
 description = "Secure remote MCP server for Obsidian vaults -- access your notes from Claude, your phone, or any MCP client, anywhere"
 readme = "README.md"
 requires-python = ">=3.12"

--- a/src/obsidian_vault_mcp/tools/recurring.py
+++ b/src/obsidian_vault_mcp/tools/recurring.py
@@ -335,16 +335,44 @@ def _list_template_paths(folder: str) -> list[str]:
     return paths
 
 
-def _instance_dir_for(template_meta: dict[str, Any], template_path: str) -> str:
+def _instance_dir_for(
+    template_meta: dict[str, Any],
+    template_path: str,
+    warnings: list[str] | None = None,
+) -> str:
     """Return the directory (vault-relative, POSIX) where instances should be written.
 
-    Resolution order:
-      1. ``instance_folder`` in the template frontmatter (explicit).
-      2. Parent directory of the template itself (sibling layout).
+    Schema resolution (canonical key first, legacy alias second):
+      1. ``target_folder`` (canonical, Tasks-Schema v0.7+).
+      2. ``instance_folder`` (legacy alias, emits a deprecation warning
+         when used without ``target_folder``).
+      3. Parent directory of the template itself (sibling fallback).
+
+    When both keys are present, ``target_folder`` wins and a warning is
+    appended so the operator can clean up the duplicate.
     """
-    explicit = template_meta.get("instance_folder")
-    if isinstance(explicit, str) and explicit.strip():
-        return explicit.strip().strip("/\\")
+    target = template_meta.get("target_folder")
+    alias = template_meta.get("instance_folder")
+
+    canonical = target if isinstance(target, str) and target.strip() else None
+    legacy = alias if isinstance(alias, str) and alias.strip() else None
+
+    if canonical is not None and legacy is not None:
+        if warnings is not None:
+            warnings.append(
+                "both 'target_folder' and 'instance_folder' set; "
+                "'target_folder' takes precedence"
+            )
+        return canonical.strip().strip("/\\")
+    if canonical is not None:
+        return canonical.strip().strip("/\\")
+    if legacy is not None:
+        if warnings is not None:
+            warnings.append(
+                "'instance_folder' is a legacy alias; prefer 'target_folder'"
+            )
+        return legacy.strip().strip("/\\")
+
     parent = PurePosixPath(template_path).parent.as_posix()
     return parent if parent and parent != "." else ""
 
@@ -360,11 +388,79 @@ def _build_instance_filename(template_id: str, period_key: str) -> str:
     return f"recurring-{safe_id}-{safe_period}.md"
 
 
-def _instance_relpath(template_meta: dict[str, Any], template_path: str, filename: str) -> str:
-    folder = _instance_dir_for(template_meta, template_path)
+def _instance_relpath(
+    template_meta: dict[str, Any],
+    template_path: str,
+    filename: str,
+    warnings: list[str] | None = None,
+) -> str:
+    folder = _instance_dir_for(template_meta, template_path, warnings)
     if folder:
         return f"{folder}/{filename}"
     return filename
+
+
+def _resolve_inheritance(
+    template_meta: dict[str, Any],
+    warnings: list[str],
+) -> dict[str, Any]:
+    """Build the inherited frontmatter map per the canonical-with-alias schema.
+
+    Canonical form (Tasks-Schema v0.7+): ``frontmatter_to_inherit`` is a dict
+    of ``key: value`` pairs copied verbatim onto the instance. DRY: values
+    live once in the template's inheritance map, not duplicated into
+    top-level template frontmatter.
+
+    Legacy alias: ``frontmatter_to_inherit`` as a list of key names; the
+    tool looks up each key in the rest of the template frontmatter. Emits
+    a deprecation warning.
+
+    Returns the resolved ``{key: value}`` map (possibly empty). Warnings
+    are appended to the supplied list, including a "configured but
+    nothing copied" alarm that prevents lautloses Scheitern.
+    """
+    raw = template_meta.get("frontmatter_to_inherit")
+    if raw is None:
+        return {}
+
+    inherited: dict[str, Any] = {}
+
+    if isinstance(raw, dict):
+        for key, value in raw.items():
+            if not isinstance(key, str) or not key.strip():
+                warnings.append(
+                    "'frontmatter_to_inherit' contains a non-string key; ignored"
+                )
+                continue
+            inherited[key] = value
+        if not inherited:
+            warnings.append(
+                "'frontmatter_to_inherit' is configured as a dict but resolved to no fields"
+            )
+        return inherited
+
+    if isinstance(raw, list):
+        warnings.append(
+            "'frontmatter_to_inherit' as a list of keys is a legacy form; "
+            "prefer the dict {key: value} form"
+        )
+        for key in raw:
+            if not isinstance(key, str) or not key.strip():
+                continue
+            if key in template_meta:
+                inherited[key] = template_meta[key]
+        if not inherited:
+            warnings.append(
+                "'frontmatter_to_inherit' (list form) is configured but no listed "
+                "key was present in the template frontmatter; nothing inherited"
+            )
+        return inherited
+
+    warnings.append(
+        "'frontmatter_to_inherit' must be a dict (canonical) or list (legacy); "
+        f"got {type(raw).__name__}; ignored"
+    )
+    return inherited
 
 
 def _build_instance_content(
@@ -373,11 +469,17 @@ def _build_instance_content(
     template_meta: dict[str, Any],
     period_key: str,
     trigger_date: date,
+    warnings: list[str] | None = None,
 ) -> str:
-    """Render the instance markdown (frontmatter + optional body header)."""
+    """Render the instance markdown (frontmatter + optional body header).
+
+    Inheritance is resolved via :func:`_resolve_inheritance`; warnings about
+    legacy / mis-shaped inheritance configuration are appended to the
+    supplied list so the calling tool can surface them in its response.
+    """
+    sink: list[str] = warnings if warnings is not None else []
     due_offset = int(template_meta.get("due_offset_days", 0) or 0)
     priority_initial = template_meta.get("priority_initial")
-    inherit_keys = template_meta.get("frontmatter_to_inherit") or []
     tags_to_inherit = template_meta.get("tags_to_inherit") or []
     title_template = template_meta.get("instance_title")
 
@@ -400,15 +502,11 @@ def _build_instance_content(
     if priority_initial is not None:
         metadata["priority"] = priority_initial
 
-    # Inherit explicit frontmatter keys from the template.
-    if isinstance(inherit_keys, list):
-        for key in inherit_keys:
-            if not isinstance(key, str):
-                continue
-            if key in template_meta:
-                metadata[key] = template_meta[key]
+    # Inherit explicit frontmatter fields from the template (dict or legacy list).
+    for key, value in _resolve_inheritance(template_meta, sink).items():
+        metadata[key] = value
 
-    # Tags: marker tag + inherited tags + any tags inside an inherit_keys "tags" entry.
+    # Tags: marker tag + inherited tags.
     tags: list[str] = ["recurring-instance"]
     if isinstance(tags_to_inherit, list):
         for tag in tags_to_inherit:
@@ -568,13 +666,14 @@ def _process_template(
     created: list[dict[str, Any]] = []
     skipped: list[dict[str, Any]] = []
     errors: list[dict[str, Any]] = []
+    warnings: list[dict[str, Any]] = []
 
     template_id = template_meta.get("id") or template_meta.get("template_id")
     if not template_id:
         errors.append(
             {"path": template_path, "error": "template missing 'id' or 'template_id' frontmatter"}
         )
-        return {"created": created, "skipped": skipped, "errors": errors}
+        return {"created": created, "skipped": skipped, "errors": errors, "warnings": warnings}
     template_id = str(template_id)
 
     anchor_mode = (template_meta.get("recurrence_anchor_mode") or "").strip().lower()
@@ -589,7 +688,7 @@ def _process_template(
                 ),
             }
         )
-        return {"created": created, "skipped": skipped, "errors": errors}
+        return {"created": created, "skipped": skipped, "errors": errors, "warnings": warnings}
 
     try:
         if anchor_mode == "absolute":
@@ -608,7 +707,7 @@ def _process_template(
                         "reason": "not_due",
                     }
                 )
-                return {"created": created, "skipped": skipped, "errors": errors}
+                return {"created": created, "skipped": skipped, "errors": errors, "warnings": warnings}
         else:
             interval_spec = (template_meta.get("recurrence_interval") or "").strip()
             if not interval_spec:
@@ -633,13 +732,13 @@ def _process_template(
                             "next_trigger": _format_iso(candidate.trigger_date),
                         }
                     )
-                    return {"created": created, "skipped": skipped, "errors": errors}
+                    return {"created": created, "skipped": skipped, "errors": errors, "warnings": warnings}
                 periods = [candidate]
     except AnchorError as exc:
         errors.append(
             {"path": template_path, "template_id": template_id, "error": str(exc)}
         )
-        return {"created": created, "skipped": skipped, "errors": errors}
+        return {"created": created, "skipped": skipped, "errors": errors, "warnings": warnings}
 
     if not periods:
         skipped.append(
@@ -649,7 +748,7 @@ def _process_template(
                 "reason": "no_pending_periods",
             }
         )
-        return {"created": created, "skipped": skipped, "errors": errors}
+        return {"created": created, "skipped": skipped, "errors": errors, "warnings": warnings}
 
     last_processed_trigger: date | None = None
     for period in periods:
@@ -666,13 +765,25 @@ def _process_template(
             continue
 
         filename = _build_instance_filename(template_id, period.period_key)
-        rel_path = _instance_relpath(template_meta, template_path, filename)
+        warn_messages: list[str] = []
+        rel_path = _instance_relpath(
+            template_meta, template_path, filename, warn_messages
+        )
         content = _build_instance_content(
             template_id=template_id,
             template_meta=template_meta,
             period_key=period.period_key,
             trigger_date=period.trigger_date,
+            warnings=warn_messages,
         )
+        for msg in warn_messages:
+            warnings.append(
+                {
+                    "template_id": template_id,
+                    "period": period.period_key,
+                    "warning": msg,
+                }
+            )
         if dry_run:
             created.append(
                 {
@@ -725,7 +836,7 @@ def _process_template(
                 }
             )
 
-    return {"created": created, "skipped": skipped, "errors": errors}
+    return {"created": created, "skipped": skipped, "errors": errors, "warnings": warnings}
 
 
 # --------------------------------------------------------------------------
@@ -794,6 +905,7 @@ def recurring_materialize(
     aggregate_created: list[dict[str, Any]] = []
     aggregate_skipped: list[dict[str, Any]] = []
     aggregate_errors: list[dict[str, Any]] = []
+    aggregate_warnings: list[dict[str, Any]] = []
     checked = 0
     matched_filter = False
 
@@ -822,6 +934,7 @@ def recurring_materialize(
         aggregate_created.extend(result["created"])
         aggregate_skipped.extend(result["skipped"])
         aggregate_errors.extend(result["errors"])
+        aggregate_warnings.extend(result.get("warnings", []))
 
     if template_id and not matched_filter:
         aggregate_errors.append(
@@ -834,6 +947,7 @@ def recurring_materialize(
             "created": aggregate_created,
             "skipped": aggregate_skipped,
             "errors": aggregate_errors,
+            "warnings": aggregate_warnings,
             "dry_run": dry_run,
             "as_of": _format_iso(as_of_date),
             "catchup_mode": catchup,

--- a/tests/test_recurring.py
+++ b/tests/test_recurring.py
@@ -244,6 +244,7 @@ last_run: 2026-04-30
 
 
 def test_absolute_quarter_end_creates_instance(recurring_vault):
+    """Canonical schema: target_folder + frontmatter_to_inherit as dict."""
     vault, index = recurring_vault
     tpl = _write_template(
         vault,
@@ -253,17 +254,15 @@ type: recurring-template
 active: true
 recurrence_anchor_mode: absolute
 recurrence_anchor: quarter_end_plus_3d
-instance_folder: tasks
+target_folder: tasks
 due_offset_days: 0
 priority_initial: 2
 last_run: 2026-06-30
 frontmatter_to_inherit:
-  - scope
-  - project
+  scope: privat
+  project: garagenkauf
 tags_to_inherit:
   - tucho
-scope: privat
-project: garagenkauf
 """,
     )
     _refresh_template_index(index, tpl)
@@ -274,6 +273,7 @@ project: garagenkauf
     assert created["period"] == "q2-2026"
     assert created["trigger_date"] == "2026-07-03"
     assert created["path"] == "tasks/recurring-tucho-quarterly-q2-2026.md"
+    assert result["warnings"] == []
     instance_path = vault / "tasks" / "recurring-tucho-quarterly-q2-2026.md"
     assert instance_path.exists()
 
@@ -285,6 +285,134 @@ project: garagenkauf
     assert "project: garagenkauf" in raw
     assert "recurring-instance" in raw
     assert "tucho" in raw
+
+
+def test_instance_folder_alias_still_works_with_warning(recurring_vault):
+    """Legacy alias `instance_folder` writes to the same place but warns."""
+    vault, index = recurring_vault
+    tpl = _write_template(
+        vault,
+        "legacy.md",
+        """id: legacy
+type: recurring-template
+active: true
+recurrence_anchor_mode: absolute
+recurrence_anchor: month_end
+instance_folder: tasks
+last_run: 2026-04-30
+""",
+    )
+    _refresh_template_index(index, tpl)
+    result = json.loads(recurring_materialize(as_of="2026-05-31"))
+    assert len(result["created"]) == 1
+    assert (vault / "tasks" / "recurring-legacy-2026-05.md").exists()
+    assert any("instance_folder" in w["warning"] for w in result["warnings"])
+
+
+def test_target_folder_wins_when_both_present(recurring_vault):
+    """If both target_folder and instance_folder are set, target_folder wins."""
+    vault, index = recurring_vault
+    tpl = _write_template(
+        vault,
+        "conflict.md",
+        """id: conflict
+type: recurring-template
+active: true
+recurrence_anchor_mode: absolute
+recurrence_anchor: month_end
+target_folder: tasks-canonical
+instance_folder: tasks-legacy
+last_run: 2026-04-30
+""",
+    )
+    (vault / "tasks-canonical").mkdir()
+    (vault / "tasks-legacy").mkdir()
+    _refresh_template_index(index, tpl)
+    result = json.loads(recurring_materialize(as_of="2026-05-31"))
+    assert len(result["created"]) == 1
+    assert (vault / "tasks-canonical" / "recurring-conflict-2026-05.md").exists()
+    assert not (vault / "tasks-legacy" / "recurring-conflict-2026-05.md").exists()
+    assert any(
+        "both 'target_folder' and 'instance_folder'" in w["warning"]
+        for w in result["warnings"]
+    )
+
+
+def test_frontmatter_to_inherit_legacy_list_warns(recurring_vault):
+    """List form copies values from template meta but emits a deprecation warning."""
+    vault, index = recurring_vault
+    tpl = _write_template(
+        vault,
+        "list.md",
+        """id: list-form
+type: recurring-template
+active: true
+recurrence_anchor_mode: absolute
+recurrence_anchor: month_end
+target_folder: tasks
+last_run: 2026-04-30
+frontmatter_to_inherit:
+  - scope
+  - project
+scope: privat
+project: foo
+""",
+    )
+    _refresh_template_index(index, tpl)
+    result = json.loads(recurring_materialize(as_of="2026-05-31"))
+    assert len(result["created"]) == 1
+    raw = (vault / "tasks" / "recurring-list-form-2026-05.md").read_text(encoding="utf-8")
+    assert "scope: privat" in raw
+    assert "project: foo" in raw
+    assert any("legacy" in w["warning"] for w in result["warnings"])
+
+
+def test_frontmatter_to_inherit_list_with_no_matches_warns(recurring_vault):
+    """List form referencing missing keys emits the 'nothing inherited' warning."""
+    vault, index = recurring_vault
+    tpl = _write_template(
+        vault,
+        "empty-list.md",
+        """id: empty-list
+type: recurring-template
+active: true
+recurrence_anchor_mode: absolute
+recurrence_anchor: month_end
+target_folder: tasks
+last_run: 2026-04-30
+frontmatter_to_inherit:
+  - scope_typo
+  - project_typo
+""",
+    )
+    _refresh_template_index(index, tpl)
+    result = json.loads(recurring_materialize(as_of="2026-05-31"))
+    assert len(result["created"]) == 1
+    assert any(
+        "nothing inherited" in w["warning"] for w in result["warnings"]
+    )
+
+
+def test_frontmatter_to_inherit_invalid_type_warns(recurring_vault):
+    """Non-dict, non-list form emits a type warning."""
+    vault, index = recurring_vault
+    tpl = _write_template(
+        vault,
+        "bogus.md",
+        """id: bogus-inherit
+type: recurring-template
+active: true
+recurrence_anchor_mode: absolute
+recurrence_anchor: month_end
+target_folder: tasks
+last_run: 2026-04-30
+frontmatter_to_inherit: "should-be-a-dict-not-a-string"
+""",
+    )
+    _refresh_template_index(index, tpl)
+    result = json.loads(recurring_materialize(as_of="2026-05-31"))
+    assert len(result["created"]) == 1
+    assert any("must be a dict" in w["warning"] for w in result["warnings"])
 
 
 def test_absolute_no_last_run_does_not_backfill(recurring_vault):


### PR DESCRIPTION
## Summary

Aligns the recurring-template schema with Tasks-Schema v0.7+ (canonical: `target_folder` + dict-form `frontmatter_to_inherit`). Legacy keys (`instance_folder`, list-form `frontmatter_to_inherit`) remain as aliases with deprecation warnings.

## Why

Discovered during the v0.8.1 live-smoke against `smoke-test` and `uva-belege-quartal` templates. Two real misalignments:

1. **Folder key drift**: template used `target_folder` (per vault Tasks-Schema), code read `instance_folder`. Result: instance landed in template's parent dir, not the configured subfolder.
2. **Inheritance form drift**: template used dict form `{scope: privat, ...}` (DRY), code expected list form `[scope, ...]` reading from top-level template frontmatter. Result: **complete silent inheritance failure** -- not a single field copied to the instance, no error surfaced.

Both fixed without forcing templates to change.

## Behavior

| Schema | Canonical | Legacy alias | If both |
|---|---|---|---|
| Instance folder | `target_folder` | `instance_folder` | `target_folder` wins + warning |
| Inheritance | `frontmatter_to_inherit: {key: value}` dict | `frontmatter_to_inherit: [key]` list | dict wins |

Plus: any `frontmatter_to_inherit` configuration that resolves to zero copied fields produces a warning. No more silent inheritance failure.

## Response contract change

Tool response gains a top-level `warnings` field (alongside `created/skipped/errors`):

```json
{
  "checked": 1,
  "created": [...],
  "skipped": [],
  "errors": [],
  "warnings": [
    {"template_id": "legacy", "period": "2026-05", "warning": "'instance_folder' is a legacy alias; prefer 'target_folder'"}
  ],
  ...
}
```

## Test plan

- [x] `pytest tests/test_recurring.py` → 46 passed (was 41; +5 alias / warning tests)
- [x] `pytest tests/` → 277 passed, zero regressions
- [ ] Live retry against `smoke-test` + `uva-belege-quartal` after merge with the canonical schema verified end-to-end

## References

- Builds on #8 (v0.8.1 — bootstrap semantics), #7 (v0.8.0 — recurring feature)
- Closes the live-smoke spec-gap from the 2026-05-31 session

🤖 Generated with [Claude Code](https://claude.com/claude-code)