### PR TITLE
feat(recurring): use template.created as implicit bootstrap baseline (v0.8.3)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,22 @@ This project follows semantic versioning. Release dates use YYYY-MM-DD.
 
 ## [Unreleased]
 
+## [v0.8.3] - 2026-05-31
+
+### Changed
+- **Bootstrap baseline for absolute templates uses the template's `created` date** when `last_run` is absent. An anchor fires when its trigger is on or after `created` and on or before `as_of`. Pre-v0.8.3 behavior would silently `skipped: not_due` even at the anchor moment itself, losing a full period for templates installed before their first anchor (e.g. quarterly templates installed mid-quarter would miss the next quarter end and only fire the one after that).
+- Anchors strictly before `created` still `skipped: not_due` — no retroactive backfill of pre-template history. Anchors strictly after `as_of` likewise `skipped: not_due`. The change only opens the bootstrap window between those two endpoints.
+
+### Invariant
+- `last_run` remains tool-managed only. To shift the bootstrap baseline, hand-edit `created` (not `last_run`).
+
+### Docs
+- `docs/recurring.md` "Bootstrap behavior" section rewritten for the new absolute path; the Q2-UVA example illustrates the typical use case.
+
+### Tests
+- 4 new cases for the bootstrap-with-created paths: trigger ON `as_of` fires, trigger before `created` is `not_due`, trigger after `as_of` is `not_due`, no anchor in window is `not_due`. The previous "always not_due without last_run" test is rewritten to require `created` to also be absent.
+- 49 recurring cases total, 280 in the full suite, zero regressions.
+
 ## [v0.8.2] - 2026-05-31
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Production-hardened fork of [`jimprosser/obsidian-web-mcp`](https://github.com/jimprosser/obsidian-web-mcp): an HTTP-based MCP server that exposes an Obsidian vault to LLM clients such as Claude, ChatGPT, and Codex over OAuth 2.0.
 
-**Latest release:** [v0.8.2](https://github.com/mleitnercom/obsidian-web-mcp/releases/tag/v0.8.2) (2026-05-31)
+**Latest release:** [v0.8.3](https://github.com/mleitnercom/obsidian-web-mcp/releases/tag/v0.8.3) (2026-05-31)
 
 ## At a Glance
 

--- a/docs/recurring.md
+++ b/docs/recurring.md
@@ -110,23 +110,32 @@ The semantics on the very first invocation of a freshly installed template
 (no `last_run` yet, no done instances) differ by mode. This is deliberate:
 the two modes encode different intents.
 
-### Absolute templates: conservative
+### Absolute templates: `created` is the implicit baseline
 
-Without `last_run`, an absolute template **does not fire**, regardless of
-whether the anchor has already triggered or is still in the future. The
-template is reported as `skipped: not_due`.
+Without `last_run`, the tool uses the template's `created` frontmatter
+date as an implicit baseline. An anchor fires when its trigger date is
+on or after `created` AND on or before `as_of`. Specifically:
 
-Why: a freshly installed `quarter_end_plus_1d` template at the end of May
-should not claim that Q1 is open as an inbox task — that period is usually
-already handled elsewhere (an accountant filed the VAT, a colleague closed
-the report). Surfacing it as an overdue task is a false alarm. The first
-real firing happens once `last_run` exists; the second run with `since`
-in place then catches up from there.
+- Anchor trigger **before** `created` → `skipped: not_due` (no retroactive
+  claim that historical periods are open).
+- Anchor trigger **between `created` and `as_of`** (inclusive on both ends)
+  → fires. This is the bootstrap moment: the first matching anchor
+  produces the first real instance and `last_run` is set accordingly.
+- Anchor trigger **after `as_of`** → `skipped: not_due` (future).
 
-Operator note: the tool itself sets `last_run` only after a real firing
-(non-dry-run). To "arm" a freshly installed absolute template without
-materializing past periods, write a `last_run` field by hand to the date
-you consider the baseline.
+Without both `last_run` AND `created`, the template stays `not_due` forever
+— the tool cannot tell what "since template existence" means. For UI-created
+notes that omit `created`, set one by hand once.
+
+Why: a freshly installed `quarter_end_plus_1d` template anchored on
+2026-07-01 should fire on 2026-07-01 without operator intervention. The
+previous (v0.8.1) behavior would have skipped silently and missed Q2
+entirely; the next firing would have been Q3 on 2026-10-01 — one full
+period lost.
+
+Operator note: `last_run` is set only by the tool itself on real
+(non-dry-run) firings. To shift the bootstrap baseline forward, hand-edit
+`created`, not `last_run`.
 
 ### Relative templates: bootstrap with today
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "obsidian-web-mcp"
-version = "0.8.2"
+version = "0.8.3"
 description = "Secure remote MCP server for Obsidian vaults -- access your notes from Claude, your phone, or any MCP client, anywhere"
 readme = "README.md"
 requires-python = ">=3.12"

--- a/src/obsidian_vault_mcp/tools/recurring.py
+++ b/src/obsidian_vault_mcp/tools/recurring.py
@@ -696,10 +696,25 @@ def _process_template(
             if not anchor:
                 raise AnchorError("template missing 'recurrence_anchor' for absolute mode")
             since = _coerce_date(template_meta.get("last_run"))
+            implicit_baseline_used = False
+            if since is None:
+                # Bootstrap: use the template's `created` date as an implicit
+                # baseline. This lets a freshly installed quarterly template
+                # actually fire when its first anchor arrives, without
+                # forcing the operator to hand-seed last_run. Subtract one
+                # day so a trigger ON the baseline date itself qualifies
+                # as "after baseline".
+                implicit = _coerce_date(template_meta.get("created"))
+                if implicit is not None:
+                    since = implicit - timedelta(days=1)
+                    implicit_baseline_used = True
             periods = compute_pending_periods(anchor, as_of, since, catchup=catchup)
-            # Bootstrap: no last_run AND no fired period -> mark not_due so
-            # the next call advances normally once last_run is in place.
-            if not periods and since is None:
+            # Bootstrap: no baseline at all (neither last_run nor created)
+            # OR baseline present but nothing fired in scope -> not_due.
+            if not periods and (
+                since is None
+                or implicit_baseline_used
+            ):
                 skipped.append(
                     {
                         "path": template_path,

--- a/tests/test_recurring.py
+++ b/tests/test_recurring.py
@@ -415,8 +415,8 @@ frontmatter_to_inherit: "should-be-a-dict-not-a-string"
     assert any("must be a dict" in w["warning"] for w in result["warnings"])
 
 
-def test_absolute_no_last_run_does_not_backfill(recurring_vault):
-    """Fresh absolute template + already-fired anchor in the past -> not_due."""
+def test_absolute_no_last_run_no_created_does_not_backfill(recurring_vault):
+    """Fresh absolute template + no created date -> not_due (no baseline)."""
     vault, index = recurring_vault
     tpl = _write_template(
         vault,
@@ -426,17 +426,87 @@ type: recurring-template
 active: true
 recurrence_anchor_mode: absolute
 recurrence_anchor: quarter_end_plus_1d
-instance_folder: tasks
+target_folder: tasks
 due_offset_days: 30
 """,
     )
     _refresh_template_index(index, tpl)
-    # Q1 ends 2026-03-31, +1d = 2026-04-01. As_of 2026-05-30 is after.
-    # Pre-patch behaviour was to backfill q1. Post-patch: not_due.
     result = json.loads(recurring_materialize(as_of="2026-05-30"))
     assert result["created"] == []
     assert any(s.get("reason") == "not_due" for s in result["skipped"])
     assert not list((vault / "tasks").glob("recurring-uva-*.md"))
+
+
+def test_absolute_bootstrap_with_created_fires_at_anchor(recurring_vault):
+    """Template `created` acts as implicit baseline. Anchor at as_of fires."""
+    vault, index = recurring_vault
+    tpl = _write_template(
+        vault,
+        "uva.md",
+        """id: uva
+type: recurring-template
+active: true
+recurrence_anchor_mode: absolute
+recurrence_anchor: quarter_end_plus_1d
+target_folder: tasks
+due_offset_days: 30
+created: 2026-04-01
+""",
+    )
+    _refresh_template_index(index, tpl)
+    # Q2 trigger 2026-07-01. as_of == trigger.
+    result = json.loads(recurring_materialize(as_of="2026-07-01"))
+    assert len(result["created"]) == 1
+    created_entry = result["created"][0]
+    assert created_entry["period"] == "q2-2026"
+    assert created_entry["trigger_date"] == "2026-07-01"
+    assert (vault / "tasks" / "recurring-uva-q2-2026.md").exists()
+
+
+def test_absolute_bootstrap_anchor_before_created_is_not_due(recurring_vault):
+    """Anchor predating template `created` is not retroactively fired."""
+    vault, index = recurring_vault
+    tpl = _write_template(
+        vault,
+        "uva.md",
+        """id: uva-late
+type: recurring-template
+active: true
+recurrence_anchor_mode: absolute
+recurrence_anchor: quarter_end_plus_1d
+target_folder: tasks
+created: 2026-05-01
+""",
+    )
+    _refresh_template_index(index, tpl)
+    # Q1 trigger 2026-04-01 < created 2026-05-01 -> ignore.
+    # Q2 trigger 2026-07-01 > as_of 2026-06-30 -> not yet.
+    result = json.loads(recurring_materialize(as_of="2026-06-30"))
+    assert result["created"] == []
+    assert any(s.get("reason") == "not_due" for s in result["skipped"])
+
+
+def test_absolute_bootstrap_no_anchor_between_created_and_as_of(recurring_vault):
+    """No anchor in (created, as_of] -> not_due even with created baseline."""
+    vault, index = recurring_vault
+    tpl = _write_template(
+        vault,
+        "uva.md",
+        """id: uva-fut
+type: recurring-template
+active: true
+recurrence_anchor_mode: absolute
+recurrence_anchor: quarter_end_plus_1d
+target_folder: tasks
+created: 2026-04-02
+""",
+    )
+    _refresh_template_index(index, tpl)
+    # created=2026-04-02 (q1 already past), as_of=2026-06-15 (before q2 trigger).
+    # No anchor in window -> not_due.
+    result = json.loads(recurring_materialize(as_of="2026-06-15"))
+    assert result["created"] == []
+    assert any(s.get("reason") == "not_due" for s in result["skipped"])
 
 
 def test_absolute_no_last_run_future_anchor_also_not_due(recurring_vault):


### PR DESCRIPTION
## Summary

Refines the v0.8.1 absolute-mode bootstrap rule so a freshly installed quarterly template actually fires on its first anchor date instead of skipping silently and losing a full period.

## Why

Discovered during the v0.8.2 live-smoke. UVA template with anchor `quarter_end_plus_1d` and `as_of=2026-07-01` returned `skipped: not_due` — because `last_run` was absent and v0.8.1 treated "no last_run" as "never fire historically". But 2026-07-01 IS the Q2 anchor moment, not history. The template would have stayed silent until Q3 (2026-10-01), missing a full period.

Same pattern applies to any periodic absolute template installed before its first anchor: yearly tax tasks, quarterly governance reviews, monthly closeouts. All would lose their first period.

## Behavior

When `last_run` is absent, the tool falls back to the template's `created` frontmatter date as an implicit baseline. An anchor fires when its trigger is on or after `created` AND on or before `as_of`:

| Trigger position | Behavior |
|---|---|
| `< created` | `skipped: not_due` (no retroactive backfill) |
| `>= created AND <= as_of` | **fires** (bootstrap moment) |
| `> as_of` | `skipped: not_due` (future) |

Without BOTH `last_run` and `created`, the template stays `not_due` forever — the tool has no baseline to reason from. Set `created` once by hand if the template file omits it.

## Invariant preserved

`last_run` remains tool-managed. To shift the bootstrap baseline, hand-edit `created`, not `last_run`. The "last_run is never user-set" invariant from v0.8.1 still holds.

## Test plan

- [x] `pytest tests/test_recurring.py` → 49 passed (was 46; +4 baseline-window tests, -1 reshaped)
- [x] `pytest tests/` → 280 passed, zero regressions
- [ ] Live retry against `uva-belege-quartal` after merge: with template `created: 2026-04-01` and `as_of=2026-07-01`, expect q2-2026 to fire

## References

- Closes the live-smoke gap from the 2026-05-31 session
- Builds on #9 (v0.8.2 schema aliases), #8 (v0.8.1 bootstrap), #7 (v0.8.0 base feature)

🤖 Generated with [Claude Code](https://claude.com/claude-code)