### PR TITLE
fix(oauth): fail closed at /oauth/authorize when no login configured

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@ dist/
 wheels/
 *.egg-info
 .venv/
+venv/
 .env
 uv.lock
 .pytest-tmp*/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ This project follows semantic versioning. Release dates use YYYY-MM-DD.
 
 ## [Unreleased]
 
+## [v0.8.4] - 2026-06-11
+
 ### Security
 - `/oauth/authorize` now **fails closed** when no login credentials are configured. Previously, with `VAULT_OAUTH_AUTH_USERNAME`/`VAULT_OAUTH_AUTH_PASSWORD` unset, the endpoint auto-approved and issued an authorization code to any caller, who could then exchange it for the vault bearer token. The endpoint now returns `503 server_error` in that state.
 - New `VAULT_OAUTH_ALLOW_NO_AUTH` env var (default `false`) is the explicit, intentionally insecure opt-in that restores unauthenticated auto-approval for local/dev use. Production deployments should leave it unset and configure login credentials instead.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@ This project follows semantic versioning. Release dates use YYYY-MM-DD.
 
 ## [Unreleased]
 
+### Security
+- `/oauth/authorize` now **fails closed** when no login credentials are configured. Previously, with `VAULT_OAUTH_AUTH_USERNAME`/`VAULT_OAUTH_AUTH_PASSWORD` unset, the endpoint auto-approved and issued an authorization code to any caller, who could then exchange it for the vault bearer token. The endpoint now returns `503 server_error` in that state.
+- New `VAULT_OAUTH_ALLOW_NO_AUTH` env var (default `false`) is the explicit, intentionally insecure opt-in that restores unauthenticated auto-approval for local/dev use. Production deployments should leave it unset and configure login credentials instead.
+- Mirrors the upstream GHSA-hwhg-mrjc-8g43 remediation (this fork already fixed the `/oauth/token` PKCE/client-identity and `/oauth/register` secret-leak issues in v0.7.3 and v0.6.x).
+
+### Tests
+- 3 new cases in `tests/test_oauth_hardening.py`: fail-closed without credentials (503), explicit opt-in restores auto-approval (302), and login form is shown when credentials are configured. The fixture now opts into auto-approval explicitly so the client-auth/PKCE cases stay focused.
+
 ## [v0.8.3] - 2026-05-31
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Production-hardened fork of [`jimprosser/obsidian-web-mcp`](https://github.com/jimprosser/obsidian-web-mcp): an HTTP-based MCP server that exposes an Obsidian vault to LLM clients such as Claude, ChatGPT, and Codex over OAuth 2.0.
 
-**Latest release:** [v0.8.3](https://github.com/mleitnercom/obsidian-web-mcp/releases/tag/v0.8.3) (2026-05-31)
+**Latest release:** [v0.8.4](https://github.com/mleitnercom/obsidian-web-mcp/releases/tag/v0.8.4) (2026-06-11)
 
 ## At a Glance
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -25,6 +25,7 @@ All configuration is read from environment variables at process startup.
 | `VAULT_OAUTH_AUTH_PASSWORD` | empty | Optional authorize-page password |
 | `VAULT_OAUTH_SESSION_SECRET` | empty | Cookie/session signing secret |
 | `VAULT_OAUTH_REQUIRE_APPROVAL` | `true` | Require approval click after login |
+| `VAULT_OAUTH_ALLOW_NO_AUTH` | `false` | Insecure opt-in: allow unauthenticated auto-approval at `/oauth/authorize` when no login credentials are set. Leave unset in production. |
 | `VAULT_OAUTH_PERSIST_REGISTERED_CLIENTS` | `true` | Persist dynamic client registrations |
 | `VAULT_OAUTH_REGISTERED_CLIENT_STORE_PATH` | semantic cache path + `oauth_registered_clients.json` | Registered-client store |
 | `VAULT_REGISTERED_CLIENT_TTL_SECONDS` | `0` | Dynamic client TTL; `0` disables expiry |

--- a/docs/oauth.md
+++ b/docs/oauth.md
@@ -71,4 +71,20 @@ VAULT_OAUTH_AUTH_PASSWORD=REPLACE_WITH_PASSWORD
 VAULT_OAUTH_REQUIRE_APPROVAL=true
 ```
 
+### Fail-closed authorization
+
+When no login credentials are configured, `/oauth/authorize` **fails closed**: it
+refuses to issue authorization codes and returns `503 server_error`. This prevents
+the endpoint from auto-approving and handing the vault bearer token to any caller
+that can reach the URL.
+
+For local development or testing where unauthenticated auto-approval is acceptable,
+set the explicit opt-in:
+
+```env
+VAULT_OAUTH_ALLOW_NO_AUTH=true
+```
+
+Leave this unset in production and configure login credentials instead.
+
 Do not store tokens or secrets in the vault, README, release notes, or smoke docs.

--- a/docs/security.md
+++ b/docs/security.md
@@ -58,6 +58,8 @@ Binary operations enforce media type and size checks:
 
 Set `VAULT_ALLOWED_HOSTS` and `VAULT_PUBLIC_BASE_URL` when using a tunnel or reverse proxy. Use `VAULT_OAUTH_AUTH_USERNAME` and `VAULT_OAUTH_AUTH_PASSWORD` for browser login before authorization.
 
+`/oauth/authorize` fails closed when no login credentials are configured: it returns `503` instead of auto-approving and handing out the vault bearer token. `VAULT_OAUTH_ALLOW_NO_AUTH=true` is an explicit, insecure opt-in for local/dev only — never set it in production.
+
 ## Audit Privacy
 
 Audit uses `token_id_hash`, not raw tokens. Do not add secrets to hook payloads. Hook stdin receives the same JSON record as the JSONL audit line and nothing extra.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "obsidian-web-mcp"
-version = "0.8.3"
+version = "0.8.4"
 description = "Secure remote MCP server for Obsidian vaults -- access your notes from Claude, your phone, or any MCP client, anywhere"
 readme = "README.md"
 requires-python = ">=3.12"

--- a/src/obsidian_vault_mcp/config.py
+++ b/src/obsidian_vault_mcp/config.py
@@ -87,6 +87,11 @@ VAULT_OAUTH_AUTH_USERNAME = os.environ.get("VAULT_OAUTH_AUTH_USERNAME", "")
 VAULT_OAUTH_AUTH_PASSWORD = os.environ.get("VAULT_OAUTH_AUTH_PASSWORD", "")
 VAULT_OAUTH_SESSION_SECRET = os.environ.get("VAULT_OAUTH_SESSION_SECRET", "")
 VAULT_OAUTH_REQUIRE_APPROVAL = _env_bool("VAULT_OAUTH_REQUIRE_APPROVAL", True)
+# Fail closed by default: when no login credentials are configured the
+# /oauth/authorize endpoint refuses to issue authorization codes. Set this to
+# true only for local development/testing where unauthenticated auto-approval
+# is acceptable.
+VAULT_OAUTH_ALLOW_NO_AUTH = _env_bool("VAULT_OAUTH_ALLOW_NO_AUTH", False)
 VAULT_OAUTH_PERSIST_REGISTERED_CLIENTS = _env_bool("VAULT_OAUTH_PERSIST_REGISTERED_CLIENTS", True)
 VAULT_PUBLIC_BASE_URL = os.environ.get("VAULT_PUBLIC_BASE_URL", "").strip().rstrip("/")
 TRUSTED_PROXY_IPS = os.environ.get("VAULT_TRUSTED_PROXY_IPS", "127.0.0.1,::1")

--- a/src/obsidian_vault_mcp/oauth.py
+++ b/src/obsidian_vault_mcp/oauth.py
@@ -454,6 +454,23 @@ async def oauth_authorize(request: Request):
     except ValueError as e:
         return JSONResponse({"error": "rate_limited", "error_description": str(e)}, status_code=429)
 
+    # Fail closed: without configured login credentials we never auto-issue an
+    # authorization code (which would hand any caller a vault bearer token).
+    # Unauthenticated auto-approval is only allowed via an explicit opt-in.
+    if not _oauth_login_enabled() and not config.VAULT_OAUTH_ALLOW_NO_AUTH:
+        logger.error(
+            "Refusing /oauth/authorize: no VAULT_OAUTH_AUTH_USERNAME/PASSWORD configured. "
+            "Set login credentials, or set VAULT_OAUTH_ALLOW_NO_AUTH=1 to explicitly allow "
+            "unauthenticated auto-approval (insecure, local/dev only)."
+        )
+        return JSONResponse(
+            {
+                "error": "server_error",
+                "error_description": "authorization server is not configured for user authentication",
+            },
+            status_code=503,
+        )
+
     if request.method == "POST":
         try:
             form = await request.form()

--- a/tests/test_oauth_hardening.py
+++ b/tests/test_oauth_hardening.py
@@ -45,6 +45,9 @@ def oauth_client(monkeypatch, tmp_path):
     monkeypatch.setattr(oauth.config, "VAULT_OAUTH_CLIENT_ID", ENV_CLIENT_ID)
     monkeypatch.setattr(oauth.config, "VAULT_OAUTH_CLIENT_SECRET", ENV_CLIENT_SECRET)
     monkeypatch.setattr(oauth.config, "VAULT_OAUTH_PERSIST_REGISTERED_CLIENTS", False)
+    # These tests exercise the client-auth/PKCE paths, not the interactive login
+    # gate, so opt into unauthenticated auto-approval explicitly.
+    monkeypatch.setattr(oauth.config, "VAULT_OAUTH_ALLOW_NO_AUTH", True)
     monkeypatch.setattr(
         oauth.config,
         "VAULT_OAUTH_REGISTERED_CLIENT_STORE_PATH",
@@ -283,6 +286,40 @@ def test_client_credentials_grant_accepts_registered(oauth_client):
     )
     assert response.status_code == 200
     assert response.json()["access_token"] == "vault-test-token"
+
+
+# --- /authorize fail-closed when no login configured ----------------------
+
+
+def test_authorize_fails_closed_without_login_credentials(oauth_client, monkeypatch):
+    """With no login configured and no opt-in, /authorize refuses (503)."""
+    monkeypatch.setattr(oauth.config, "VAULT_OAUTH_AUTH_USERNAME", "")
+    monkeypatch.setattr(oauth.config, "VAULT_OAUTH_AUTH_PASSWORD", "")
+    monkeypatch.setattr(oauth.config, "VAULT_OAUTH_ALLOW_NO_AUTH", False)
+    response, _ = _authorize(oauth_client, ENV_CLIENT_ID)
+    assert response.status_code == 503
+    assert response.json()["error"] == "server_error"
+
+
+def test_authorize_auto_approves_with_explicit_opt_in(oauth_client, monkeypatch):
+    """The explicit VAULT_OAUTH_ALLOW_NO_AUTH opt-in restores auto-approval."""
+    monkeypatch.setattr(oauth.config, "VAULT_OAUTH_AUTH_USERNAME", "")
+    monkeypatch.setattr(oauth.config, "VAULT_OAUTH_AUTH_PASSWORD", "")
+    monkeypatch.setattr(oauth.config, "VAULT_OAUTH_ALLOW_NO_AUTH", True)
+    response, _ = _authorize(oauth_client, ENV_CLIENT_ID)
+    assert response.status_code == 302
+    assert "code=" in response.headers["location"]
+
+
+def test_authorize_shows_login_form_when_credentials_configured(oauth_client, monkeypatch):
+    """With login credentials set, /authorize gates behind the login form."""
+    monkeypatch.setattr(oauth.config, "VAULT_OAUTH_AUTH_USERNAME", "operator")
+    monkeypatch.setattr(oauth.config, "VAULT_OAUTH_AUTH_PASSWORD", "correct horse")
+    monkeypatch.setattr(oauth.config, "VAULT_OAUTH_ALLOW_NO_AUTH", False)
+    response, _ = _authorize(oauth_client, ENV_CLIENT_ID)
+    assert response.status_code == 200
+    assert "Vault MCP Login" in response.text
+    assert "code=" not in response.text
 
 
 # --- MCP protocol-version probe -------------------------------------------

--- a/tests/test_security.py
+++ b/tests/test_security.py
@@ -538,6 +538,7 @@ def test_oauth_authorize_alias_works(monkeypatch):
     oauth._auth_codes.clear()
     oauth._registered_clients.clear()
     monkeypatch.setattr(oauth.config, "VAULT_MCP_TOKEN", "vault-token")
+    monkeypatch.setattr(oauth.config, "VAULT_OAUTH_ALLOW_NO_AUTH", True)
 
     _, challenge = _pkce_pair()
 
@@ -570,6 +571,7 @@ def test_oauth_authorize_login_then_issues_code(monkeypatch):
     oauth._auth_codes.clear()
     oauth._registered_clients.clear()
     monkeypatch.setattr(oauth.config, "VAULT_MCP_TOKEN", "vault-token")
+    monkeypatch.setattr(oauth.config, "VAULT_OAUTH_ALLOW_NO_AUTH", True)
     monkeypatch.setattr(oauth.config, "VAULT_OAUTH_AUTH_USERNAME", "michael")
     monkeypatch.setattr(oauth.config, "VAULT_OAUTH_AUTH_PASSWORD", "correct horse battery staple")
     monkeypatch.setattr(oauth.config, "VAULT_OAUTH_SESSION_SECRET", "session-secret")
@@ -743,6 +745,7 @@ def test_oauth_public_pkce_client_can_exchange_code_without_secret(monkeypatch):
     oauth._auth_codes.clear()
     oauth._registered_clients.clear()
     monkeypatch.setattr(oauth.config, "VAULT_MCP_TOKEN", "vault-token")
+    monkeypatch.setattr(oauth.config, "VAULT_OAUTH_ALLOW_NO_AUTH", True)
     code_verifier = "dBjftJeZ4CVP-mB92K27uhbUJU1p1r_wW1gFWFOEjXk"
     code_challenge = base64.urlsafe_b64encode(
         hashlib.sha256(code_verifier.encode("ascii")).digest()
@@ -835,6 +838,7 @@ def test_oauth_success_logs_do_not_include_secret_material(monkeypatch, caplog):
     oauth._auth_codes.clear()
     oauth._registered_clients.clear()
     monkeypatch.setattr(oauth.config, "VAULT_MCP_TOKEN", "vault-token-secret")
+    monkeypatch.setattr(oauth.config, "VAULT_OAUTH_ALLOW_NO_AUTH", True)
 
     code_verifier = "verifier-secret-material"
     code_challenge = base64.urlsafe_b64encode(
@@ -887,11 +891,12 @@ def test_oauth_success_logs_do_not_include_secret_material(monkeypatch, caplog):
     assert registration["client_secret"] not in logs
 
 
-def test_oauth_authorize_rejects_unregistered_redirect_uri():
+def test_oauth_authorize_rejects_unregistered_redirect_uri(monkeypatch):
     """Authorization rejects redirect URIs that were not registered for the client."""
     reset_rate_limits()
     oauth._auth_codes.clear()
     oauth._registered_clients.clear()
+    monkeypatch.setattr(oauth.config, "VAULT_OAUTH_ALLOW_NO_AUTH", True)
 
     app = Starlette(routes=oauth.oauth_routes)
     with TestClient(app) as client:


### PR DESCRIPTION
## Summary

`/oauth/authorize` now **fails closed** when no login credentials are configured. Previously, with `VAULT_OAUTH_AUTH_USERNAME`/`VAULT_OAUTH_AUTH_PASSWORD` unset, the endpoint auto-approved and issued an authorization code to **any** caller, who could then exchange it for the vault bearer token (full read/write). This is the same class of issue as upstream advisory **GHSA-hwhg-mrjc-8g43**; the token-endpoint (PKCE/client-identity) and `/oauth/register` secret-leak parts were already fixed in this fork (v0.7.3 / v0.6.x).

## Changes

- `/oauth/authorize` returns `503 server_error` when login credentials are not configured, instead of auto-issuing a code.
- New `VAULT_OAUTH_ALLOW_NO_AUTH` env var (default `false`) — explicit, intentionally insecure opt-in that restores unauthenticated auto-approval for local/dev use.
- Docs updated: `docs/oauth.md`, `docs/configuration.md`, `docs/security.md`, CHANGELOG.
- `.gitignore`: add `venv/`.

## Tests

- 3 new cases in `tests/test_oauth_hardening.py`: fail-closed (503), explicit opt-in restores 302, login form shown when credentials configured.
- Existing flow tests in `test_security.py` and the hardening fixture updated to opt in explicitly.
- Full suite green: **282 passed, 1 skipped**.

## Notes

This is also a clean candidate to upstream to `jimprosser/obsidian-web-mcp` alongside the GHSA remediation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)