### PR TITLE
fix: emit non-ASCII tool responses as UTF-8 (not \uXXXX)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ This project follows semantic versioning. Release dates use YYYY-MM-DD.
 
 ## [Unreleased]
 
+### Fixed
+- Tool responses now emit non-ASCII text as UTF-8 instead of `\uXXXX` escape sequences. `vault_json_dumps` defaulted to `ensure_ascii=True` (the stdlib `json.dumps` default), which inflated token counts for non-ASCII vaults and broke verbatim round-trips of non-ASCII paths. It now defaults `ensure_ascii=False`; callers can still override it for ASCII-only on-disk state. Mirrors the upstream fix in jimprosser/obsidian-web-mcp#38 / issue #49.
+
+### Tests
+- `tests/test_json_utf8.py`: non-ASCII emitted verbatim (no `\u` escapes), `ensure_ascii=True` override still works, date-encoder still applied.
+
 ## [v0.8.4] - 2026-06-11
 
 ### Security

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ This project follows semantic versioning. Release dates use YYYY-MM-DD.
 
 ## [Unreleased]
 
+## [v0.8.5] - 2026-06-11
+
 ### Fixed
 - Tool responses now emit non-ASCII text as UTF-8 instead of `\uXXXX` escape sequences. `vault_json_dumps` defaulted to `ensure_ascii=True` (the stdlib `json.dumps` default), which inflated token counts for non-ASCII vaults and broke verbatim round-trips of non-ASCII paths. It now defaults `ensure_ascii=False`; callers can still override it for ASCII-only on-disk state. Mirrors the upstream fix in jimprosser/obsidian-web-mcp#38 / issue #49.
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Production-hardened fork of [`jimprosser/obsidian-web-mcp`](https://github.com/jimprosser/obsidian-web-mcp): an HTTP-based MCP server that exposes an Obsidian vault to LLM clients such as Claude, ChatGPT, and Codex over OAuth 2.0.
 
-**Latest release:** [v0.8.4](https://github.com/mleitnercom/obsidian-web-mcp/releases/tag/v0.8.4) (2026-06-11)
+**Latest release:** [v0.8.5](https://github.com/mleitnercom/obsidian-web-mcp/releases/tag/v0.8.5) (2026-06-11)
 
 ## At a Glance
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "obsidian-web-mcp"
-version = "0.8.4"
+version = "0.8.5"
 description = "Secure remote MCP server for Obsidian vaults -- access your notes from Claude, your phone, or any MCP client, anywhere"
 readme = "README.md"
 requires-python = ">=3.12"

--- a/src/obsidian_vault_mcp/vault.py
+++ b/src/obsidian_vault_mcp/vault.py
@@ -58,7 +58,15 @@ class _DateAwareEncoder(json.JSONEncoder):
 
 
 def vault_json_dumps(obj: object, **kwargs) -> str:
-    """``json.dumps`` replacement that handles ``datetime.date`` values."""
+    """``json.dumps`` replacement that handles ``datetime.date`` values and
+    emits non-ASCII text as UTF-8 instead of ``\\uXXXX`` escapes.
+
+    ``ensure_ascii`` defaults to ``False`` so tool responses stay compact for
+    non-ASCII vaults and round-trip non-ASCII paths/content verbatim. Callers
+    may still override it (e.g. pass ``ensure_ascii=True`` for ASCII-only
+    on-disk state).
+    """
+    kwargs.setdefault("ensure_ascii", False)
     return json.dumps(obj, cls=_DateAwareEncoder, **kwargs)
 
 

--- a/tests/test_json_utf8.py
+++ b/tests/test_json_utf8.py
@@ -1,0 +1,28 @@
+"""Tool responses must emit non-ASCII as UTF-8, not \\uXXXX escapes (issue #49).
+
+ensure_ascii=True (json.dumps default) escapes every non-ASCII character, which
+inflates token counts for non-ASCII vaults and breaks verbatim round-trips of
+non-ASCII paths. vault_json_dumps defaults ensure_ascii=False to avoid that.
+"""
+
+import datetime
+
+from obsidian_vault_mcp.vault import vault_json_dumps
+
+
+def test_non_ascii_emitted_as_utf8_not_escaped():
+    payload = {"title": "Erklärung", "path": "70_Privat/Müll/Größe.md"}
+    out = vault_json_dumps(payload)
+    assert "Erklärung" in out
+    assert "Größe" in out
+    assert "\\u" not in out  # no escape sequences
+
+
+def test_ensure_ascii_override_still_supported():
+    out = vault_json_dumps({"x": "ä"}, ensure_ascii=True)
+    assert "\\u00e4" in out
+
+
+def test_date_encoder_still_applied():
+    out = vault_json_dumps({"d": datetime.date(2026, 6, 11)})
+    assert "2026-06-11" in out


### PR DESCRIPTION
## Summary

`vault_json_dumps` (the central serializer for all tool responses) inherited `json.dumps`'s default `ensure_ascii=True`, which escapes every non-ASCII character into a `\uXXXX` sequence. For non-ASCII vaults (this one is largely German) that:

- **inflates token counts** in every response (`Erklärung` → `Erklärung`), and
- **breaks verbatim round-trips** of non-ASCII file paths.

Now defaults `ensure_ascii=False`; callers can still override it (e.g. the upload-registry state file stays ASCII via the direct `json.dumps` path, which is unaffected).

## Changes

- `src/obsidian_vault_mcp/vault.py`: `vault_json_dumps` sets `ensure_ascii=False` by default.
- `tests/test_json_utf8.py`: non-ASCII emitted verbatim (no `\u`), `ensure_ascii=True` override still works, date-encoder still applied.

## Tests

Full suite green: **285 passed, 1 skipped**.

## Context

Mirrors the upstream fix [jimprosser/obsidian-web-mcp#38](https://github.com/jimprosser/obsidian-web-mcp/pull/38) / issue #49 — same root cause, independently confirmed in this fork.

🤖 Generated with [Claude Code](https://claude.com/claude-code)