### PR TITLE
fix: non-UTF-8 filename crash (#14) + empty old_str data-loss (#13)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,16 @@ This project follows semantic versioning. Release dates use YYYY-MM-DD.
 
 ## [Unreleased]
 
+## [v0.8.6] - 2026-06-11
+
+### Fixed
+- **Non-UTF-8 filenames no longer break whole tool responses (#14, regression from v0.8.5).** After v0.8.5 switched `vault_json_dumps` to `ensure_ascii=False`, a file whose on-disk name is not valid UTF-8 (a lone surrogate via `surrogateescape`) was emitted verbatim and the MCP transport then failed to UTF-8 encode the entire response, taking neighbouring valid notes down with it. `vault_json_dumps` now verifies UTF-8 encodability and falls back to escaped output for that one response only, preserving the v0.8.5 token savings for every valid-UTF-8 vault. Mirrors the second half of upstream jimprosser/obsidian-web-mcp#38.
+- **`vault_str_replace` / `vault_batch_replace` no longer corrupt files on an empty `old_str` with `replace_all=True` (#13).** `str.count("")` returns `len+1` (never 0) and `str.replace("", new)` interleaves `new` between every character, slipping past the not-found and uniqueness guards; the atomic-write read-back did not catch it. `_replace_in_content` now rejects an empty `old_str` up front.
+
+### Tests
+- `tests/test_json_utf8.py`: a lone-surrogate payload stays UTF-8 encodable and round-trips.
+- `tests/test_replace_guards.py`: empty `old_str` (and a missing `old_str` key in batch) is rejected and leaves the file untouched.
+
 ## [v0.8.5] - 2026-06-11
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Production-hardened fork of [`jimprosser/obsidian-web-mcp`](https://github.com/jimprosser/obsidian-web-mcp): an HTTP-based MCP server that exposes an Obsidian vault to LLM clients such as Claude, ChatGPT, and Codex over OAuth 2.0.
 
-**Latest release:** [v0.8.5](https://github.com/mleitnercom/obsidian-web-mcp/releases/tag/v0.8.5) (2026-06-11)
+**Latest release:** [v0.8.6](https://github.com/mleitnercom/obsidian-web-mcp/releases/tag/v0.8.6) (2026-06-11)
 
 ## At a Glance
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "obsidian-web-mcp"
-version = "0.8.5"
+version = "0.8.6"
 description = "Secure remote MCP server for Obsidian vaults -- access your notes from Claude, your phone, or any MCP client, anywhere"
 readme = "README.md"
 requires-python = ">=3.12"

--- a/src/obsidian_vault_mcp/tools/write.py
+++ b/src/obsidian_vault_mcp/tools/write.py
@@ -684,6 +684,11 @@ def _replace_in_content(
     new_str: str,
     replace_all: bool,
 ) -> dict:
+    if old_str == "":
+        # An empty old_str is a data-loss trap: str.count("") returns len+1
+        # (never 0, so the not-found guard misses it) and str.replace("", new)
+        # interleaves new between every character. Reject it explicitly.
+        return {"error": "old_str must be a non-empty string", "path": path}
     occurrences = content.count(old_str)
     if occurrences == 0:
         return {"error": "old_str not found in file", "path": path}

--- a/src/obsidian_vault_mcp/vault.py
+++ b/src/obsidian_vault_mcp/vault.py
@@ -65,9 +65,22 @@ def vault_json_dumps(obj: object, **kwargs) -> str:
     non-ASCII vaults and round-trip non-ASCII paths/content verbatim. Callers
     may still override it (e.g. pass ``ensure_ascii=True`` for ASCII-only
     on-disk state).
+
+    Guard: a vault file whose on-disk name is not valid UTF-8 reaches Python as
+    a lone surrogate (via ``surrogateescape``). With ``ensure_ascii=False`` that
+    surrogate is emitted verbatim and the MCP transport then fails to UTF-8
+    encode the *whole* response. We verify encodability and fall back to escaped
+    output for that one response, so a single odd filename cannot take down an
+    otherwise valid payload.
     """
     kwargs.setdefault("ensure_ascii", False)
-    return json.dumps(obj, cls=_DateAwareEncoder, **kwargs)
+    result = json.dumps(obj, cls=_DateAwareEncoder, **kwargs)
+    if not kwargs["ensure_ascii"]:
+        try:
+            result.encode("utf-8")
+        except UnicodeEncodeError:
+            result = json.dumps(obj, cls=_DateAwareEncoder, **{**kwargs, "ensure_ascii": True})
+    return result
 
 
 class OcrError(RuntimeError):

--- a/tests/test_json_utf8.py
+++ b/tests/test_json_utf8.py
@@ -26,3 +26,19 @@ def test_ensure_ascii_override_still_supported():
 def test_date_encoder_still_applied():
     out = vault_json_dumps({"d": datetime.date(2026, 6, 11)})
     assert "2026-06-11" in out
+
+
+def test_lone_surrogate_filename_stays_utf8_encodable():
+    """A non-UTF-8 filename (lone surrogate) must not break the whole response (#14).
+
+    os.listdir decodes invalid bytes via surrogateescape, so a Latin-1 'café.md'
+    arrives as 'bad\\udce9name.md'. ensure_ascii=False would emit it verbatim and
+    the MCP transport's .encode('utf-8') would then fail for the entire payload.
+    The guard falls back to escaped output for that one response.
+    """
+    out = vault_json_dumps({"path": "bad\udce9name.md", "ok": "Größe"})
+    # transport requirement: the whole response must be UTF-8 encodable
+    out.encode("utf-8")  # would raise UnicodeEncodeError without the guard
+    # and the value still round-trips
+    import json
+    assert json.loads(out)["path"] == "bad\udce9name.md"

--- a/tests/test_replace_guards.py
+++ b/tests/test_replace_guards.py
@@ -1,0 +1,33 @@
+"""An empty old_str must never corrupt a file via replace_all (issue #13).
+
+str.count("") returns len+1 (never 0, so the not-found guard misses it) and
+str.replace("", new) interleaves new between every character. Both
+vault_str_replace and vault_batch_replace route through _replace_in_content,
+which now rejects an empty old_str before counting.
+"""
+
+import json
+
+from obsidian_vault_mcp.tools.write import vault_str_replace, vault_batch_replace
+
+ORIGINAL = "# Title\n\nalpha beta gamma\n"
+
+
+def test_str_replace_rejects_empty_old_str(vault_dir):
+    note = vault_dir / "note.md"
+    note.write_text(ORIGINAL, encoding="utf-8")
+
+    result = json.loads(vault_str_replace("note.md", old_str="", new_str="X", replace_all=True))
+
+    assert "error" in result
+    assert note.read_text(encoding="utf-8") == ORIGINAL  # file untouched
+
+
+def test_batch_replace_missing_old_str_does_not_corrupt(vault_dir):
+    note = vault_dir / "note.md"
+    note.write_text(ORIGINAL, encoding="utf-8")
+
+    # omitting old_str defaults it to "" in vault_batch_replace
+    json.loads(vault_batch_replace([{"path": "note.md", "new_str": "X", "replace_all": True}]))
+
+    assert note.read_text(encoding="utf-8") == ORIGINAL


### PR DESCRIPTION
## Summary

Fixes both issues opened by @ProfessionalSeaweedDevourer.

### #14 — non-UTF-8 filename breaks whole responses (regression from v0.8.5)
v0.8.5 switched `vault_json_dumps` to `ensure_ascii=False`. A file whose on-disk name is not valid UTF-8 arrives as a lone surrogate (`surrogateescape`); `ensure_ascii=False` emits it verbatim and the MCP transport then fails to UTF-8 encode the **entire** response, hiding neighbouring valid notes too. `vault_json_dumps` now verifies UTF-8 encodability and falls back to escaped output **for that one response only** — valid-UTF-8 vaults keep the v0.8.5 token savings. Mirrors the second half of upstream jimprosser/obsidian-web-mcp#38.

### #13 — empty `old_str` + `replace_all=True` corrupts the file
`str.count("")` returns `len+1` (never 0) and `str.replace("", new)` interleaves `new` between every character, slipping past the not-found and uniqueness guards; the atomic-write read-back can't catch it (the corrupted content is what was written). `_replace_in_content` now rejects an empty `old_str` up front. Covers both `vault_str_replace` and `vault_batch_replace` (which defaults a missing `old_str` to `""`).

## Tests
- `tests/test_json_utf8.py`: lone-surrogate payload stays UTF-8 encodable and round-trips.
- `tests/test_replace_guards.py`: empty / missing `old_str` rejected, file left untouched.
- Full suite green locally: **288 passed, 1 skipped**.

Closes #13
Closes #14

🤖 Generated with [Claude Code](https://claude.com/claude-code)