### PR TITLE
feat(config): converge server/transport env vars to VAULT_MCP_* (deprecated aliases kept)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,15 @@ This project follows semantic versioning. Release dates use YYYY-MM-DD.
 
 ## [Unreleased]
 
+## [v0.8.7] - 2026-06-13
+
+### Changed
+- **Server/transport env vars converged to upstream's `VAULT_MCP_*` names**, to lower the friction of pulling future upstream changes back into this fork. Canonical names now: `VAULT_MCP_ALLOWED_HOSTS`, `VAULT_MCP_FORWARDED_ALLOW_IPS`, `VAULT_MCP_PUBLIC_URL`. The previous names (`VAULT_ALLOWED_HOSTS`, `VAULT_TRUSTED_PROXY_IPS`, `VAULT_PUBLIC_BASE_URL`) keep working as **deprecated aliases** and emit a one-line warning, so existing systemd units / `.env` files are not broken. OAuth (`VAULT_OAUTH_AUTH_*`) is intentionally left unchanged — the fork's auth design differs from upstream's.
+- Added `VAULT_MCP_HOST` (default `0.0.0.0`, preserving current bind behavior) so the listen host is configurable and named like upstream, instead of hard-coding `0.0.0.0` in `server.py`.
+
+### Tests
+- `tests/test_config_aliases.py`: canonical name wins, deprecated alias is honored with a warning, default applies when neither is set (scalar and CSV variants).
+
 ## [v0.8.6] - 2026-06-11
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Production-hardened fork of [`jimprosser/obsidian-web-mcp`](https://github.com/jimprosser/obsidian-web-mcp): an HTTP-based MCP server that exposes an Obsidian vault to LLM clients such as Claude, ChatGPT, and Codex over OAuth 2.0.
 
-**Latest release:** [v0.8.6](https://github.com/mleitnercom/obsidian-web-mcp/releases/tag/v0.8.6) (2026-06-11)
+**Latest release:** [v0.8.7](https://github.com/mleitnercom/obsidian-web-mcp/releases/tag/v0.8.7) (2026-06-13)
 
 ## At a Glance
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -11,9 +11,10 @@ All configuration is read from environment variables at process startup.
 | `VAULT_PATH` | `~/Obsidian/MyVault` | Vault root directory |
 | `VAULT_MCP_TOKEN` | empty | Bearer token for MCP requests |
 | `VAULT_MCP_PORT` | `8420` | HTTP listen port |
-| `VAULT_ALLOWED_HOSTS` | `127.0.0.1:*`, `localhost:*`, `[::1]:*` | Host allowlist for DNS rebinding protection |
-| `VAULT_PUBLIC_BASE_URL` | empty | External HTTPS base URL for OAuth metadata and signed uploads |
-| `VAULT_TRUSTED_PROXY_IPS` | `127.0.0.1,::1` | Proxy IPs trusted for forwarded headers |
+| `VAULT_MCP_HOST` | `0.0.0.0` | Bind host (default `0.0.0.0`; set to `127.0.0.1` when a proxy/tunnel runs on the same host) |
+| `VAULT_MCP_ALLOWED_HOSTS` | `127.0.0.1:*`, `localhost:*`, `[::1]:*` | Host allowlist for DNS rebinding protection (deprecated alias: `VAULT_ALLOWED_HOSTS`) |
+| `VAULT_MCP_PUBLIC_URL` | empty | External HTTPS base URL for OAuth metadata and signed uploads (deprecated alias: `VAULT_PUBLIC_BASE_URL`) |
+| `VAULT_MCP_FORWARDED_ALLOW_IPS` | `127.0.0.1,::1` | Proxy IPs trusted for forwarded headers (deprecated alias: `VAULT_TRUSTED_PROXY_IPS`) |
 
 ## OAuth
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "obsidian-web-mcp"
-version = "0.8.6"
+version = "0.8.7"
 description = "Secure remote MCP server for Obsidian vaults -- access your notes from Claude, your phone, or any MCP client, anywhere"
 readme = "README.md"
 requires-python = ">=3.12"

--- a/src/obsidian_vault_mcp/config.py
+++ b/src/obsidian_vault_mcp/config.py
@@ -1,6 +1,35 @@
 import json
+import logging
 import os
 from pathlib import Path
+
+_logger = logging.getLogger(__name__)
+
+
+def _env_alias_raw(canonical: str, alias: str) -> str:
+    """Return the canonical env var; fall back to a deprecated alias.
+
+    Convergence toward upstream's ``VAULT_MCP_*`` server/transport names while
+    keeping the fork's older names working. The canonical name wins; the legacy
+    alias is honored with a one-line deprecation warning so existing
+    deployments (systemd units, .env files) do not break.
+    """
+    value = os.environ.get(canonical, "")
+    if value.strip():
+        return value
+    legacy = os.environ.get(alias, "")
+    if legacy.strip():
+        _logger.warning("Env var %s is deprecated; use %s instead.", alias, canonical)
+        return legacy
+    return ""
+
+
+def _env_csv_with_alias(canonical: str, alias: str, default: list[str]) -> list[str]:
+    """Comma-separated env var with canonical/deprecated-alias resolution."""
+    raw = _env_alias_raw(canonical, alias)
+    if not raw.strip():
+        return default
+    return [item.strip() for item in raw.split(",") if item.strip()]
 
 
 def _env_int(name: str, default: int) -> int:
@@ -93,12 +122,19 @@ VAULT_OAUTH_REQUIRE_APPROVAL = _env_bool("VAULT_OAUTH_REQUIRE_APPROVAL", True)
 # is acceptable.
 VAULT_OAUTH_ALLOW_NO_AUTH = _env_bool("VAULT_OAUTH_ALLOW_NO_AUTH", False)
 VAULT_OAUTH_PERSIST_REGISTERED_CLIENTS = _env_bool("VAULT_OAUTH_PERSIST_REGISTERED_CLIENTS", True)
-VAULT_PUBLIC_BASE_URL = os.environ.get("VAULT_PUBLIC_BASE_URL", "").strip().rstrip("/")
-TRUSTED_PROXY_IPS = os.environ.get("VAULT_TRUSTED_PROXY_IPS", "127.0.0.1,::1")
-ALLOWED_HOSTS = _env_csv(
+# Server/transport config converged to upstream's VAULT_MCP_* names; the older
+# fork names remain as deprecated aliases (see _env_alias_raw).
+VAULT_PUBLIC_BASE_URL = _env_alias_raw("VAULT_MCP_PUBLIC_URL", "VAULT_PUBLIC_BASE_URL").strip().rstrip("/")
+TRUSTED_PROXY_IPS = _env_alias_raw("VAULT_MCP_FORWARDED_ALLOW_IPS", "VAULT_TRUSTED_PROXY_IPS") or "127.0.0.1,::1"
+ALLOWED_HOSTS = _env_csv_with_alias(
+    "VAULT_MCP_ALLOWED_HOSTS",
     "VAULT_ALLOWED_HOSTS",
     ["127.0.0.1:*", "localhost:*", "[::1]:*"],
 )
+# Bind host. Default 0.0.0.0 preserves the fork's behavior (cloudflared runs on
+# a separate VM and reaches the server over the LAN); upstream defaults to
+# loopback. Matching the VAULT_MCP_HOST name keeps the knob aligned.
+VAULT_MCP_HOST = os.environ.get("VAULT_MCP_HOST", "0.0.0.0").strip() or "0.0.0.0"
 INCLUDED_ROOTS = _env_csv("VAULT_INCLUDED_ROOTS", ["."])
 EXCLUDED_PATH_PREFIXES = _env_csv("VAULT_EXCLUDED_PATH_PREFIXES", [])
 EXTRA_BINARY_MEDIA_TYPES = _env_binary_media_type_map("VAULT_EXTRA_BINARY_MEDIA_TYPES_JSON")

--- a/src/obsidian_vault_mcp/server.py
+++ b/src/obsidian_vault_mcp/server.py
@@ -1577,12 +1577,12 @@ def main():
     try:
         _log_oauth_runtime_summary()
         app = build_app()
-        logger.info(f"Starting server on port {VAULT_MCP_PORT} with bearer auth + OAuth")
+        logger.info(f"Starting server on {config.VAULT_MCP_HOST}:{VAULT_MCP_PORT} with bearer auth + OAuth")
 
         import uvicorn
         uvicorn.run(
             app,
-            host="0.0.0.0",
+            host=config.VAULT_MCP_HOST,
             port=VAULT_MCP_PORT,
             log_level="info",
             access_log=False,

--- a/tests/test_config_aliases.py
+++ b/tests/test_config_aliases.py
@@ -1,0 +1,43 @@
+"""Server/transport env vars converged to VAULT_MCP_* names; the older fork
+names keep working as deprecated aliases (with a one-line warning)."""
+
+import logging
+
+from obsidian_vault_mcp.config import _env_alias_raw, _env_csv_with_alias
+
+
+def test_canonical_wins_over_alias(monkeypatch):
+    monkeypatch.setenv("VAULT_MCP_PUBLIC_URL", "https://canonical")
+    monkeypatch.setenv("VAULT_PUBLIC_BASE_URL", "https://legacy")
+    assert _env_alias_raw("VAULT_MCP_PUBLIC_URL", "VAULT_PUBLIC_BASE_URL") == "https://canonical"
+
+
+def test_alias_used_with_deprecation_warning(monkeypatch, caplog):
+    monkeypatch.delenv("VAULT_MCP_PUBLIC_URL", raising=False)
+    monkeypatch.setenv("VAULT_PUBLIC_BASE_URL", "https://legacy")
+    with caplog.at_level(logging.WARNING, logger="obsidian_vault_mcp.config"):
+        value = _env_alias_raw("VAULT_MCP_PUBLIC_URL", "VAULT_PUBLIC_BASE_URL")
+    assert value == "https://legacy"
+    assert any("deprecated" in r.getMessage() for r in caplog.records)
+
+
+def test_returns_empty_when_neither_set(monkeypatch):
+    monkeypatch.delenv("VAULT_MCP_PUBLIC_URL", raising=False)
+    monkeypatch.delenv("VAULT_PUBLIC_BASE_URL", raising=False)
+    assert _env_alias_raw("VAULT_MCP_PUBLIC_URL", "VAULT_PUBLIC_BASE_URL") == ""
+
+
+def test_csv_alias_resolution(monkeypatch):
+    monkeypatch.delenv("VAULT_MCP_ALLOWED_HOSTS", raising=False)
+    monkeypatch.setenv("VAULT_ALLOWED_HOSTS", "a.example, b.example")
+    assert _env_csv_with_alias(
+        "VAULT_MCP_ALLOWED_HOSTS", "VAULT_ALLOWED_HOSTS", ["default"]
+    ) == ["a.example", "b.example"]
+
+
+def test_csv_default_when_neither_set(monkeypatch):
+    monkeypatch.delenv("VAULT_MCP_ALLOWED_HOSTS", raising=False)
+    monkeypatch.delenv("VAULT_ALLOWED_HOSTS", raising=False)
+    assert _env_csv_with_alias(
+        "VAULT_MCP_ALLOWED_HOSTS", "VAULT_ALLOWED_HOSTS", ["default"]
+    ) == ["default"]


### PR DESCRIPTION
## Summary

Convergence Phase 0: align the fork's **server/transport** env-var names with upstream's `VAULT_MCP_*` convention so future upstream changes are cheaper to pull back. Non-breaking — old names keep working as deprecated aliases.

| Canonical (new) | Deprecated alias (still works) |
|---|---|
| `VAULT_MCP_ALLOWED_HOSTS` | `VAULT_ALLOWED_HOSTS` |
| `VAULT_MCP_FORWARDED_ALLOW_IPS` | `VAULT_TRUSTED_PROXY_IPS` |
| `VAULT_MCP_PUBLIC_URL` | `VAULT_PUBLIC_BASE_URL` |

- Alias resolution via `_env_alias_raw` / `_env_csv_with_alias`: canonical wins; alias is honored with a one-line deprecation warning; default applies when neither is set. Existing systemd units / `.env` files are not broken.
- Added `VAULT_MCP_HOST` (default `0.0.0.0`, preserving current bind behavior) instead of hard-coding the host in `server.py`.
- **OAuth names (`VAULT_OAUTH_AUTH_*`) intentionally unchanged** — the fork's auth design differs from upstream's, so reusing upstream's `VAULT_OAUTH_*` names would mean same-name/different-behavior.

## Tests

`tests/test_config_aliases.py` (5 cases): canonical wins, alias honored with warning, default when neither set (scalar + CSV). Full suite green locally: **293 passed, 1 skipped**.

## Notes

Fork-internal convergence (upstream already uses these names); not an upstream PR. The production systemd unit still uses the old names — they keep working via the aliases (one deprecation warning per affected var in the startup log) until the unit is updated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)