### PR TITLE
feat: add upstream-compatible vault_edit tool (convergence)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@ This project follows semantic versioning. Release dates use YYYY-MM-DD.
 
 ## [Unreleased]
 
+## [v0.8.8] - 2026-06-13
+
+### Added
+- **`vault_edit` tool — upstream-compatible edit contract.** Applies an ordered list of exact text replacements to a file in one call: each `old_text` must match exactly once, edits apply in order, and `dry_run=true` returns a unified diff without writing. Accepts `old_str`/`new_str` as aliases for `old_text`/`new_text`. Writes go through the verified atomic path; the tool is audited as a mutation. Convergence toward upstream's `vault_edit` so the same edit shape works across fork and upstream; the existing `vault_str_replace` / `vault_patch` / `vault_batch_replace` tools are unchanged.
+
+### Tests
+- `tests/test_vault_edit.py` (10 cases): dry-run preview without writing, single/multiple ordered edits, `old_str`/`new_str` aliases, exactly-once enforcement (0 and >1 matches leave the file untouched), `old_text`+`old_str` conflict, missing file, model validation (empty edits / empty `old_text`), and the server wiring seam.
+
 ## [v0.8.7] - 2026-06-13
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Production-hardened fork of [`jimprosser/obsidian-web-mcp`](https://github.com/jimprosser/obsidian-web-mcp): an HTTP-based MCP server that exposes an Obsidian vault to LLM clients such as Claude, ChatGPT, and Codex over OAuth 2.0.
 
-**Latest release:** [v0.8.7](https://github.com/mleitnercom/obsidian-web-mcp/releases/tag/v0.8.7) (2026-06-13)
+**Latest release:** [v0.8.8](https://github.com/mleitnercom/obsidian-web-mcp/releases/tag/v0.8.8) (2026-06-13)
 
 ## At a Glance
 
@@ -137,6 +137,7 @@ The filesystem path is the primary path. The Plugin Bridge is additive and optio
 | `vault_import_file` | Import an allowed local/mounted file into the vault |
 | `vault_batch_frontmatter_update` | Update frontmatter fields across files |
 | `vault_batch_replace` | Replace exact strings across files |
+| `vault_edit` | Apply ordered exact text replacements (each matches once); dry-run unified-diff preview; upstream-compatible contract |
 | `vault_str_replace` | Replace exact strings in one file |
 | `vault_patch` | Replace one unique exact occurrence |
 | `vault_append` | Append content to a file |

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "obsidian-web-mcp"
-version = "0.8.7"
+version = "0.8.8"
 description = "Secure remote MCP server for Obsidian vaults -- access your notes from Claude, your phone, or any MCP client, anywhere"
 readme = "README.md"
 requires-python = ">=3.12"

--- a/src/obsidian_vault_mcp/audit.py
+++ b/src/obsidian_vault_mcp/audit.py
@@ -22,6 +22,7 @@ MUTATION_OPERATIONS = {
     "vault_write",
     "vault_write_binary",
     "vault_patch",
+    "vault_edit",
     "vault_append",
     "vault_str_replace",
     "vault_batch_replace",

--- a/src/obsidian_vault_mcp/models.py
+++ b/src/obsidian_vault_mcp/models.py
@@ -2,7 +2,7 @@
 
 from typing import Any, Literal
 
-from pydantic import BaseModel, ConfigDict, Field, field_validator
+from pydantic import BaseModel, ConfigDict, Field, field_validator, model_validator
 
 from .config import (
     CONTEXT_LINES,
@@ -719,3 +719,57 @@ class VaultBatchFrontmatterUpdateInput(BaseModel):
             if "fields" not in item or not isinstance(item["fields"], dict):
                 raise ValueError(f"updates[{i}] must contain a 'fields' key with a dict value")
         return v
+
+
+class VaultEditOperationInput(BaseModel):
+    """One exact text replacement inside a file (upstream vault_edit contract)."""
+
+    model_config = ConfigDict(str_strip_whitespace=False, extra="forbid")
+
+    @model_validator(mode="before")
+    @classmethod
+    def normalize_str_replace_aliases(cls, data):
+        if not isinstance(data, dict):
+            return data
+        normalized = dict(data)
+        for canonical, alias in (("old_text", "old_str"), ("new_text", "new_str")):
+            if canonical in normalized and alias in normalized:
+                raise ValueError(f"Use either '{canonical}' or '{alias}', not both")
+            if alias in normalized:
+                normalized[canonical] = normalized.pop(alias)
+        return normalized
+
+    old_text: str = Field(
+        ...,
+        description="Exact existing text fragment to replace; must appear exactly once",
+        min_length=1,
+        max_length=MAX_CONTENT_SIZE,
+    )
+    new_text: str = Field(
+        ...,
+        description="Replacement text for old_text (empty string deletes the matched text)",
+        max_length=MAX_CONTENT_SIZE,
+    )
+
+
+class VaultEditInput(BaseModel):
+    """Patch an existing file with ordered exact text replacements."""
+
+    model_config = ConfigDict(str_strip_whitespace=True, extra="forbid")
+
+    path: str = Field(
+        ...,
+        description="Relative path from vault root",
+        min_length=1,
+        max_length=500,
+    )
+    edits: list[VaultEditOperationInput] = Field(
+        ...,
+        description="Ordered exact text replacements to apply without resending the full file",
+        min_length=1,
+        max_length=MAX_BATCH_SIZE,
+    )
+    dry_run: bool = Field(
+        default=False,
+        description="Preview the patch and unified diff without writing the file",
+    )

--- a/src/obsidian_vault_mcp/server.py
+++ b/src/obsidian_vault_mcp/server.py
@@ -490,6 +490,7 @@ from .tools.write import (
     vault_append as _vault_append,
     vault_batch_replace as _vault_batch_replace,
     vault_batch_frontmatter_update as _vault_batch_frontmatter_update,
+    vault_edit as _vault_edit,
     vault_import_file as _vault_import_file,
     vault_patch as _vault_patch,
     vault_request_upload_url as _vault_request_upload_url,
@@ -534,6 +535,7 @@ from .models import (
     VaultReadInput,
     VaultImportFileInput,
     VaultPatchInput,
+    VaultEditInput,
     VaultRequestUploadUrlInput,
     VaultStrReplaceInput,
     VaultImportUrlInput,
@@ -959,6 +961,30 @@ def vault_str_replace(path: str, old_string: str, new_string: str = "", replace_
         old_string_bytes=len(inp.old_string.encode("utf-8")),
         new_string_bytes=len(inp.new_string.encode("utf-8")),
         replace_all=inp.replace_all,
+    )
+
+
+@mcp.tool(
+    name="vault_edit",
+    description=(
+        "Patch an existing vault file with ordered exact text replacements. Each old_text must match exactly "
+        "once; edits apply in order; set dry_run=true for a unified-diff preview without writing. Accepts "
+        "old_str/new_str as aliases. Token-efficient partial edits without resending the file."
+    ),
+    annotations={"readOnlyHint": False, "destructiveHint": True, "idempotentHint": False, "openWorldHint": False},
+)
+def vault_edit(path: str, edits: list[dict], dry_run: bool = False) -> str:
+    """Patch a file with ordered exact text replacements."""
+    inp = VaultEditInput(path=path, edits=edits, dry_run=dry_run)
+    limited = _tool_rate_limit_error("write", config.RATE_LIMIT_WRITE)
+    if limited is not None:
+        return limited
+    return _run_logged_tool(
+        "vault_edit",
+        lambda: _vault_edit(inp.path, [edit.model_dump() for edit in inp.edits], inp.dry_run),
+        path=inp.path,
+        edits=len(inp.edits),
+        dry_run=inp.dry_run,
     )
 
 

--- a/src/obsidian_vault_mcp/tools/write.py
+++ b/src/obsidian_vault_mcp/tools/write.py
@@ -2,6 +2,7 @@
 
 import base64
 import binascii
+import difflib
 import hashlib
 import hmac
 import ipaddress
@@ -80,6 +81,102 @@ def _write_text_with_verification(
             f"(expected {expected_size} bytes, read back {actual_size} bytes)"
         )
     return is_new, size
+
+
+def _unified_diff(path: str, before: str, after: str) -> str:
+    """Return a compact unified diff for an edit preview or result."""
+    return "".join(difflib.unified_diff(
+        before.splitlines(keepends=True),
+        after.splitlines(keepends=True),
+        fromfile=f"{path} before",
+        tofile=f"{path} after",
+        lineterm="",
+    ))
+
+
+def _normalize_edit_aliases(edit: dict) -> tuple[dict | None, str | None]:
+    """Map old_str/new_str aliases onto canonical old_text/new_text."""
+    normalized = dict(edit)
+    for canonical, alias in (("old_text", "old_str"), ("new_text", "new_str")):
+        if canonical in normalized and alias in normalized:
+            return None, f"Use either '{canonical}' or '{alias}', not both"
+        if alias in normalized:
+            normalized[canonical] = normalized.pop(alias)
+    return normalized, None
+
+
+def vault_edit(path: str, edits: list[dict], dry_run: bool = False) -> str:
+    """Apply ordered exact text replacements to an existing file.
+
+    Upstream-compatible contract: each edit's ``old_text`` must match exactly
+    once; edits apply in order; ``dry_run`` returns a unified diff without
+    writing. ``old_str``/``new_str`` are accepted as aliases for
+    ``old_text``/``new_text``. Writes go through the verified atomic path.
+    """
+    def _fail(message: str, *, edits_applied: int = 0, size: int = 0) -> str:
+        return vault_json_dumps({
+            "error": message,
+            "path": path,
+            "changed": False,
+            "dry_run": dry_run,
+            "diff": "",
+            "edits_applied": edits_applied,
+            "size": size,
+        })
+
+    try:
+        content, _ = read_file(path)
+        original_content = content
+        original_size = len(original_content.encode("utf-8"))
+
+        for index, edit in enumerate(edits):
+            normalized_edit, alias_error = _normalize_edit_aliases(edit)
+            if alias_error:
+                return _fail(f"Edit {index}: {alias_error}", size=original_size)
+            old_text = normalized_edit.get("old_text", "")
+            new_text = normalized_edit.get("new_text", "")
+            if old_text == "":
+                return _fail(f"Edit {index} old_text must be a non-empty string", size=original_size)
+            count = content.count(old_text)
+            if count != 1:
+                return _fail(
+                    f"Edit {index} old_text must match exactly once; found {count} matches",
+                    size=original_size,
+                )
+            content = content.replace(old_text, new_text, 1)
+
+        diff = _unified_diff(path, original_content, content)
+        size = len(content.encode("utf-8"))
+
+        if dry_run:
+            return vault_json_dumps({
+                "path": path,
+                "changed": False,
+                "dry_run": True,
+                "diff": diff,
+                "edits_applied": len(edits),
+                "size": size,
+            })
+
+        changed = content != original_content
+        if changed:
+            _write_text_with_verification(path, content, create_dirs=False)
+
+        return vault_json_dumps({
+            "path": path,
+            "changed": changed,
+            "dry_run": False,
+            "diff": diff,
+            "edits_applied": len(edits),
+            "size": size,
+        })
+    except FileNotFoundError:
+        return _fail(f"File not found: {path}")
+    except ValueError as e:
+        return _fail(str(e))
+    except Exception as e:
+        logger.error(f"vault_edit error for {path}: {e}")
+        return _fail(str(e))
 
 
 def _allowed_binary_extensions_for(media_type: str) -> set[str] | None:

--- a/tests/test_vault_edit.py
+++ b/tests/test_vault_edit.py
@@ -1,0 +1,112 @@
+"""vault_edit: upstream-compatible ordered exact replacements.
+
+Each old_text must match exactly once; edits apply in order; dry_run previews a
+unified diff without writing; old_str/new_str are accepted as aliases.
+"""
+
+import json
+from contextlib import contextmanager
+
+import pytest
+from pydantic import ValidationError
+
+from obsidian_vault_mcp import server
+from obsidian_vault_mcp.models import VaultEditInput
+from obsidian_vault_mcp.rate_limit import (
+    reset_current_auth_principal,
+    reset_current_request_metadata,
+    set_current_auth_principal,
+    set_current_request_metadata,
+)
+from obsidian_vault_mcp.tools.write import vault_edit
+
+
+@contextmanager
+def _auth_ctx():
+    principal = set_current_auth_principal("edit-test-token")
+    metadata = set_current_request_metadata({"client_family": "pytest", "request_id": "edit-req"})
+    try:
+        yield
+    finally:
+        reset_current_request_metadata(metadata)
+        reset_current_auth_principal(principal)
+
+
+def _note(vault_dir, body="alpha beta gamma\n", name="note.md"):
+    (vault_dir / name).write_text(body, encoding="utf-8")
+    return body
+
+
+def test_dry_run_previews_without_writing(vault_dir):
+    original = _note(vault_dir)
+    result = json.loads(vault_edit("note.md", [{"old_text": "beta", "new_text": "BETA"}], dry_run=True))
+    assert result["dry_run"] is True
+    assert result["changed"] is False
+    assert result["edits_applied"] == 1
+    assert "BETA" in result["diff"]
+    assert (vault_dir / "note.md").read_text(encoding="utf-8") == original  # untouched
+
+
+def test_single_edit_applies(vault_dir):
+    _note(vault_dir)
+    result = json.loads(vault_edit("note.md", [{"old_text": "beta", "new_text": "BETA"}]))
+    assert result["changed"] is True and result["dry_run"] is False
+    assert (vault_dir / "note.md").read_text(encoding="utf-8") == "alpha BETA gamma\n"
+
+
+def test_multiple_edits_applied_in_order(vault_dir):
+    _note(vault_dir, body="one two three\n")
+    result = json.loads(vault_edit("note.md", [
+        {"old_text": "one", "new_text": "1"},
+        {"old_text": "three", "new_text": "3"},
+    ]))
+    assert result["edits_applied"] == 2
+    assert (vault_dir / "note.md").read_text(encoding="utf-8") == "1 two 3\n"
+
+
+def test_old_str_new_str_aliases(vault_dir):
+    _note(vault_dir)
+    result = json.loads(vault_edit("note.md", [{"old_str": "beta", "new_str": "B"}]))
+    assert result["changed"] is True
+    assert (vault_dir / "note.md").read_text(encoding="utf-8") == "alpha B gamma\n"
+
+
+def test_zero_matches_errors_without_write(vault_dir):
+    original = _note(vault_dir)
+    result = json.loads(vault_edit("note.md", [{"old_text": "missing", "new_text": "x"}]))
+    assert "error" in result and "exactly once" in result["error"]
+    assert (vault_dir / "note.md").read_text(encoding="utf-8") == original
+
+
+def test_multiple_matches_errors_without_write(vault_dir):
+    original = _note(vault_dir, body="x x x\n")
+    result = json.loads(vault_edit("note.md", [{"old_text": "x", "new_text": "y"}]))
+    assert "error" in result and "exactly once" in result["error"]
+    assert (vault_dir / "note.md").read_text(encoding="utf-8") == original
+
+
+def test_both_old_text_and_old_str_errors(vault_dir):
+    _note(vault_dir)
+    result = json.loads(vault_edit("note.md", [{"old_text": "beta", "old_str": "beta", "new_text": "B"}]))
+    assert "error" in result and "not both" in result["error"]
+
+
+def test_missing_file_errors(vault_dir):
+    result = json.loads(vault_edit("nope.md", [{"old_text": "a", "new_text": "b"}]))
+    assert "error" in result and "not found" in result["error"].lower()
+
+
+def test_model_rejects_empty_edits_and_empty_old_text():
+    with pytest.raises(ValidationError):
+        VaultEditInput(path="note.md", edits=[])
+    with pytest.raises(ValidationError):
+        VaultEditInput(path="note.md", edits=[{"old_text": "", "new_text": "x"}])
+
+
+def test_vault_edit_registered_and_wired(vault_dir):
+    assert server.mcp._tool_manager.get_tool("vault_edit") is not None
+    _note(vault_dir)
+    with _auth_ctx():
+        result = json.loads(server.vault_edit("note.md", [{"old_text": "gamma", "new_text": "GAMMA"}]))
+    assert result["changed"] is True
+    assert (vault_dir / "note.md").read_text(encoding="utf-8") == "alpha beta GAMMA\n"


### PR DESCRIPTION
## Summary

Convergence Phase 0 (edit contract): add a `vault_edit` tool matching upstream's contract, so the same edit shape works across this fork and `jimprosser/obsidian-web-mcp`. Additive — `vault_str_replace`, `vault_patch`, and `vault_batch_replace` are unchanged.

`vault_edit(path, edits, dry_run=False)`:
- Applies an **ordered list** of exact text replacements; each `old_text` must match **exactly once**, edits apply in order.
- `dry_run=true` returns a **unified diff** without writing.
- Accepts `old_str`/`new_str` as aliases for `old_text`/`new_text`.
- Writes go through the fork's **verified atomic write path**; the tool is in `MUTATION_OPERATIONS` so it is audited.

## Tests

`tests/test_vault_edit.py` (10 cases): dry-run preview without writing, single/multiple ordered edits, aliases, exactly-once enforcement (0 and >1 matches leave the file untouched), `old_text`+`old_str` conflict, missing file, model validation (empty edits / empty `old_text`), and the server wiring seam. Full suite green: **303 passed, 1 skipped**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)