### PR TITLE
fix(config): VAULT_MCP_ALLOWED_HOSTS appends to loopback defaults (no lockout)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ This project follows semantic versioning. Release dates use YYYY-MM-DD.
 
 ## [Unreleased]
 
+## [v0.8.9] - 2026-06-13
+
+### Fixed
+- `VAULT_MCP_ALLOWED_HOSTS` now **appends** to the always-present loopback defaults instead of replacing the list. Previously, setting the env var without re-listing `127.0.0.1:*`/`localhost:*`/`[::1]:*` dropped loopback (a lockout footgun). New `effective_allowed_hosts()` composes loopback + operator hosts, de-duplicated. Matches upstream's append semantics (jimprosser/obsidian-web-mcp#34).
+
 ### Docs
 - README: added a "Relationship to upstream" section describing the cooperative fork model — generic capabilities are offered back upstream, config/tool conventions are kept aligned (`VAULT_MCP_*`, `vault_edit`), and the fork stays the daily driver with a fork-specific workflow layer.
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Production-hardened fork of [`jimprosser/obsidian-web-mcp`](https://github.com/jimprosser/obsidian-web-mcp): an HTTP-based MCP server that exposes an Obsidian vault to LLM clients such as Claude, ChatGPT, and Codex over OAuth 2.0.
 
-**Latest release:** [v0.8.8](https://github.com/mleitnercom/obsidian-web-mcp/releases/tag/v0.8.8) (2026-06-13)
+**Latest release:** [v0.8.9](https://github.com/mleitnercom/obsidian-web-mcp/releases/tag/v0.8.9) (2026-06-13)
 
 ## At a Glance
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -12,7 +12,7 @@ All configuration is read from environment variables at process startup.
 | `VAULT_MCP_TOKEN` | empty | Bearer token for MCP requests |
 | `VAULT_MCP_PORT` | `8420` | HTTP listen port |
 | `VAULT_MCP_HOST` | `0.0.0.0` | Bind host (default `0.0.0.0`; set to `127.0.0.1` when a proxy/tunnel runs on the same host) |
-| `VAULT_MCP_ALLOWED_HOSTS` | `127.0.0.1:*`, `localhost:*`, `[::1]:*` | Host allowlist for DNS rebinding protection (deprecated alias: `VAULT_ALLOWED_HOSTS`) |
+| `VAULT_MCP_ALLOWED_HOSTS` | (extra hosts only) | Extra hostnames for DNS-rebinding protection, **appended** to the always-present loopback defaults (`127.0.0.1:*`, `localhost:*`, `[::1]:*`); set only your tunnel/proxy host. Deprecated alias: `VAULT_ALLOWED_HOSTS` |
 | `VAULT_MCP_PUBLIC_URL` | empty | External HTTPS base URL for OAuth metadata and signed uploads (deprecated alias: `VAULT_PUBLIC_BASE_URL`) |
 | `VAULT_MCP_FORWARDED_ALLOW_IPS` | `127.0.0.1,::1` | Proxy IPs trusted for forwarded headers (deprecated alias: `VAULT_TRUSTED_PROXY_IPS`) |
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "obsidian-web-mcp"
-version = "0.8.8"
+version = "0.8.9"
 description = "Secure remote MCP server for Obsidian vaults -- access your notes from Claude, your phone, or any MCP client, anywhere"
 readme = "README.md"
 requires-python = ">=3.12"

--- a/src/obsidian_vault_mcp/config.py
+++ b/src/obsidian_vault_mcp/config.py
@@ -126,11 +126,29 @@ VAULT_OAUTH_PERSIST_REGISTERED_CLIENTS = _env_bool("VAULT_OAUTH_PERSIST_REGISTER
 # fork names remain as deprecated aliases (see _env_alias_raw).
 VAULT_PUBLIC_BASE_URL = _env_alias_raw("VAULT_MCP_PUBLIC_URL", "VAULT_PUBLIC_BASE_URL").strip().rstrip("/")
 TRUSTED_PROXY_IPS = _env_alias_raw("VAULT_MCP_FORWARDED_ALLOW_IPS", "VAULT_TRUSTED_PROXY_IPS") or "127.0.0.1,::1"
-ALLOWED_HOSTS = _env_csv_with_alias(
-    "VAULT_MCP_ALLOWED_HOSTS",
-    "VAULT_ALLOWED_HOSTS",
-    ["127.0.0.1:*", "localhost:*", "[::1]:*"],
-)
+# Loopback is ALWAYS allowed; operator hosts from VAULT_MCP_ALLOWED_HOSTS are
+# APPENDED, never replace it. This avoids a lockout footgun where setting the env
+# var without re-listing loopback would drop it. (Matches upstream #34.)
+ALLOWED_HOSTS_LOOPBACK_DEFAULTS = ["127.0.0.1:*", "localhost:*", "[::1]:*"]
+# Operator-supplied extra hostnames only (default empty); composed in
+# effective_allowed_hosts(). Deprecated alias VAULT_ALLOWED_HOSTS still honored.
+ALLOWED_HOSTS = _env_csv_with_alias("VAULT_MCP_ALLOWED_HOSTS", "VAULT_ALLOWED_HOSTS", [])
+
+
+def effective_allowed_hosts() -> list[str]:
+    """Loopback defaults plus operator hosts, de-duplicated, order preserved.
+
+    Loopback can never be dropped, so an operator who sets only their tunnel
+    hostname does not lock themselves out.
+    """
+    merged = [*ALLOWED_HOSTS_LOOPBACK_DEFAULTS, *ALLOWED_HOSTS]
+    seen: set[str] = set()
+    result: list[str] = []
+    for host in merged:
+        if host not in seen:
+            seen.add(host)
+            result.append(host)
+    return result
 # Bind host. Default 0.0.0.0 preserves the fork's behavior (cloudflared runs on
 # a separate VM and reaches the server over the LAN); upstream defaults to
 # loopback. Matching the VAULT_MCP_HOST name keeps the knob aligned.

--- a/src/obsidian_vault_mcp/server.py
+++ b/src/obsidian_vault_mcp/server.py
@@ -466,7 +466,7 @@ mcp = FastMCP(
     lifespan=lifespan,
     transport_security=TransportSecuritySettings(
         enable_dns_rebinding_protection=True,
-        allowed_hosts=config.ALLOWED_HOSTS,
+        allowed_hosts=config.effective_allowed_hosts(),
     ),
 )
 

--- a/tests/test_config_aliases.py
+++ b/tests/test_config_aliases.py
@@ -44,22 +44,22 @@ def test_csv_default_when_neither_set(monkeypatch):
     ) == ["default"]
 
 
+_LOOPBACK = ["127.0.0.1:*", "localhost:*", "[::1]:*"]
+
+
 def test_effective_allowed_hosts_always_includes_loopback(monkeypatch):
     monkeypatch.setattr(config, "ALLOWED_HOSTS", ["vault-mcp.example.com"])
-    hosts = config.effective_allowed_hosts()
-    assert "127.0.0.1:*" in hosts and "localhost:*" in hosts and "[::1]:*" in hosts
-    assert "vault-mcp.example.com" in hosts
-    # loopback comes first, operator host appended
-    assert hosts.index("127.0.0.1:*") < hosts.index("vault-mcp.example.com")
+    # loopback first, operator host appended (exact, ordered)
+    assert config.effective_allowed_hosts() == _LOOPBACK + ["vault-mcp.example.com"]
 
 
 def test_effective_allowed_hosts_no_lockout_when_only_custom_set(monkeypatch):
     # operator sets only their host -> loopback must NOT be dropped
     monkeypatch.setattr(config, "ALLOWED_HOSTS", ["only.example.com"])
-    assert "127.0.0.1:*" in config.effective_allowed_hosts()
+    assert config.effective_allowed_hosts()[:3] == _LOOPBACK
 
 
 def test_effective_allowed_hosts_dedups(monkeypatch):
+    # an operator entry duplicating a loopback default collapses to one
     monkeypatch.setattr(config, "ALLOWED_HOSTS", ["127.0.0.1:*", "x.example.com"])
-    hosts = config.effective_allowed_hosts()
-    assert hosts.count("127.0.0.1:*") == 1
+    assert config.effective_allowed_hosts() == _LOOPBACK + ["x.example.com"]

--- a/tests/test_config_aliases.py
+++ b/tests/test_config_aliases.py
@@ -3,6 +3,7 @@ names keep working as deprecated aliases (with a one-line warning)."""
 
 import logging
 
+from obsidian_vault_mcp import config
 from obsidian_vault_mcp.config import _env_alias_raw, _env_csv_with_alias
 
 
@@ -41,3 +42,24 @@ def test_csv_default_when_neither_set(monkeypatch):
     assert _env_csv_with_alias(
         "VAULT_MCP_ALLOWED_HOSTS", "VAULT_ALLOWED_HOSTS", ["default"]
     ) == ["default"]
+
+
+def test_effective_allowed_hosts_always_includes_loopback(monkeypatch):
+    monkeypatch.setattr(config, "ALLOWED_HOSTS", ["vault-mcp.example.com"])
+    hosts = config.effective_allowed_hosts()
+    assert "127.0.0.1:*" in hosts and "localhost:*" in hosts and "[::1]:*" in hosts
+    assert "vault-mcp.example.com" in hosts
+    # loopback comes first, operator host appended
+    assert hosts.index("127.0.0.1:*") < hosts.index("vault-mcp.example.com")
+
+
+def test_effective_allowed_hosts_no_lockout_when_only_custom_set(monkeypatch):
+    # operator sets only their host -> loopback must NOT be dropped
+    monkeypatch.setattr(config, "ALLOWED_HOSTS", ["only.example.com"])
+    assert "127.0.0.1:*" in config.effective_allowed_hosts()
+
+
+def test_effective_allowed_hosts_dedups(monkeypatch):
+    monkeypatch.setattr(config, "ALLOWED_HOSTS", ["127.0.0.1:*", "x.example.com"])
+    hosts = config.effective_allowed_hosts()
+    assert hosts.count("127.0.0.1:*") == 1


### PR DESCRIPTION
## Summary

Adopt upstream's safer append semantics for `VAULT_MCP_ALLOWED_HOSTS`. The fork had converged the **name** in v0.8.7 but kept replace semantics: setting the env var without re-listing `127.0.0.1:*`/`localhost:*`/`[::1]:*` dropped loopback (a lockout footgun).

Now loopback is always present and operator hosts are **appended**, de-duplicated, via `effective_allowed_hosts()`. `ALLOWED_HOSTS` holds only the operator extras (default empty); the deprecated alias `VAULT_ALLOWED_HOSTS` still works.

## Tests
`tests/test_config_aliases.py`: loopback always present even when only a custom host is set, operator host appended after loopback, duplicates collapsed. Full suite green: **306 passed, 1 skipped**.

## Note
Closes the last allowed-hosts divergence from upstream (jimprosser/obsidian-web-mcp#34). Prod stays safe throughout (its env value already includes loopback; with append it is simply de-duplicated).