### PR TITLE
feat: harden push-heartbeat (inbound from upstream #45) (v0.8.10)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,17 @@ This project follows semantic versioning. Release dates use YYYY-MM-DD.
 
 ## [Unreleased]
 
+## [v0.8.10] - 2026-06-14
+
+### Changed
+- **Push-heartbeat hardened (inbound from upstream jimprosser/obsidian-web-mcp#45).** The optional `VAULT_MCP_HEARTBEAT_URL` ping now refuses to follow redirects (a redirect could leak the capability URL to another host), reads at most 1 KB of the response, validates its configuration fail-closed at startup (`validate_heartbeat()` rejects a non-`http(s)` URL or a non-positive interval, so a typo cannot boot a server that silently never pings), and no longer stores or logs the raw exception on failure (it could contain the secret URL). The richer `/health` heartbeat state is unchanged.
+
+### Tests
+- `tests/test_heartbeat_hardening.py` (10 cases): `validate_heartbeat` enabled/disabled, bad URL scheme/host, non-positive interval, error messages never echo the capability URL, and the no-redirect handler.
+
+### Notes
+- Upstream's configurable mount path (jimprosser/obsidian-web-mcp#43, `VAULT_MCP_PATH`) was evaluated and intentionally **not** adopted: this fork serves MCP at `/` through its own compatibility middleware + root probe, so there is no mount-path knob to make configurable and nothing for a path validator to guard.
+
 ## [v0.8.9] - 2026-06-13
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Production-hardened fork of [`jimprosser/obsidian-web-mcp`](https://github.com/jimprosser/obsidian-web-mcp): an HTTP-based MCP server that exposes an Obsidian vault to LLM clients such as Claude, ChatGPT, and Codex over OAuth 2.0.
 
-**Latest release:** [v0.8.9](https://github.com/mleitnercom/obsidian-web-mcp/releases/tag/v0.8.9) (2026-06-13)
+**Latest release:** [v0.8.10](https://github.com/mleitnercom/obsidian-web-mcp/releases/tag/v0.8.10) (2026-06-14)
 
 ## At a Glance
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "obsidian-web-mcp"
-version = "0.8.9"
+version = "0.8.10"
 description = "Secure remote MCP server for Obsidian vaults -- access your notes from Claude, your phone, or any MCP client, anywhere"
 readme = "README.md"
 requires-python = ">=3.12"

--- a/src/obsidian_vault_mcp/config.py
+++ b/src/obsidian_vault_mcp/config.py
@@ -100,6 +100,35 @@ VAULT_MCP_PORT = _env_int("VAULT_MCP_PORT", 8420)
 VAULT_MCP_HEARTBEAT_URL = os.environ.get("VAULT_MCP_HEARTBEAT_URL", "").strip()
 VAULT_MCP_HEARTBEAT_INTERVAL = _env_int("VAULT_MCP_HEARTBEAT_INTERVAL", 60)
 VAULT_HEALTH_ALLOW_REMOTE_DETAILS = _env_bool("VAULT_HEALTH_ALLOW_REMOTE_DETAILS", False)
+
+
+def validate_heartbeat() -> int | None:
+    """Validate the heartbeat config; return the interval (seconds) when enabled.
+
+    Returns None when the heartbeat is disabled (no URL). Raises ValueError (so
+    server.main() can exit non-zero and fail CLOSED) when the URL scheme is not http(s)
+    or the interval is not a positive integer -- a typo must not boot a server that
+    silently never pings or tight-loops on interval 0. Error messages never echo the raw
+    values: the heartbeat URL is a capability URL (the secret is in the path), and a
+    misconfigured operator might swap the URL/interval env vars. (Hardening from
+    upstream #45.)
+    """
+    url = VAULT_MCP_HEARTBEAT_URL
+    if not url:
+        return None
+
+    from urllib.parse import urlsplit
+
+    try:
+        parsed = urlsplit(url)
+        _ = parsed.port  # raises ValueError on a malformed port
+    except ValueError:
+        raise ValueError("VAULT_MCP_HEARTBEAT_URL has a malformed port")
+    if parsed.scheme.lower() not in ("http", "https") or not parsed.hostname:
+        raise ValueError("VAULT_MCP_HEARTBEAT_URL must be an http(s) URL with a host")
+    if VAULT_MCP_HEARTBEAT_INTERVAL <= 0:
+        raise ValueError("VAULT_MCP_HEARTBEAT_INTERVAL must be a positive integer")
+    return VAULT_MCP_HEARTBEAT_INTERVAL
 VAULT_MCP_POST_WRITE_CMD = os.environ.get("VAULT_MCP_POST_WRITE_CMD", "").strip()
 VAULT_MCP_POST_WRITE_TIMEOUT = _env_int("VAULT_MCP_POST_WRITE_TIMEOUT", 30)
 VAULT_PDF_OCR_ENABLED = _env_bool("VAULT_PDF_OCR_ENABLED", False)

--- a/src/obsidian_vault_mcp/server.py
+++ b/src/obsidian_vault_mcp/server.py
@@ -270,11 +270,32 @@ def _tool_rate_limit_error(scope: str, limit: int) -> str | None:
     return None
 
 
+_HEARTBEAT_MAX_BYTES = 1024
+
+
+class _NoRedirect(urllib.request.HTTPRedirectHandler):
+    """Refuse to follow redirects on the heartbeat GET.
+
+    The heartbeat URL is a capability URL (the secret lives in the path); following a
+    redirect could leak it to another host. (Hardening from upstream #45.)
+    """
+
+    def redirect_request(self, *args, **kwargs):
+        return None
+
+
+_heartbeat_opener = urllib.request.build_opener(_NoRedirect)
+
+
 async def _heartbeat_loop(url: str, interval: int) -> None:
-    """Send periodic HTTP GET heartbeats to a push-style endpoint."""
+    """Send periodic HTTP GET heartbeats to a push-style endpoint.
+
+    Does not follow redirects and reads at most _HEARTBEAT_MAX_BYTES of the response.
+    """
     def _send() -> int:
-        with urllib.request.urlopen(url, timeout=10) as resp:
-            return resp.status
+        with _heartbeat_opener.open(url, timeout=10) as resp:
+            resp.read(_HEARTBEAT_MAX_BYTES)
+            return getattr(resp, "status", None) or resp.getcode()
 
     while True:
         now = datetime.now(timezone.utc).isoformat()
@@ -286,8 +307,9 @@ async def _heartbeat_loop(url: str, interval: int) -> None:
             _heartbeat_state["last_error"] = ""
             logger.debug("Heartbeat sent: HTTP %s", status)
         except Exception as exc:
-            _heartbeat_state["last_error"] = str(exc)
-            logger.debug("Heartbeat failed: %s", exc)
+            # Never store/log the raw exception: it can contain the capability URL.
+            _heartbeat_state["last_error"] = type(exc).__name__
+            logger.debug("Heartbeat failed: %s", type(exc).__name__)
         await asyncio.sleep(interval)
 
 
@@ -1599,6 +1621,14 @@ def main():
 
     if not VAULT_MCP_TOKEN:
         logger.warning("VAULT_MCP_TOKEN is not set -- auth will reject all requests")
+
+    # Fail CLOSED on a misconfigured heartbeat (bad URL scheme / non-positive interval)
+    # rather than booting a server that silently never pings. (Hardening from upstream #45.)
+    try:
+        config.validate_heartbeat()
+    except ValueError as e:
+        logger.error(f"Invalid heartbeat configuration: {e}")
+        sys.exit(1)
 
     try:
         _log_oauth_runtime_summary()

--- a/tests/test_heartbeat_hardening.py
+++ b/tests/test_heartbeat_hardening.py
@@ -1,0 +1,51 @@
+"""Hardening for the push-heartbeat (ported from upstream #45).
+
+Covers config.validate_heartbeat() fail-closed validation and the no-redirect opener.
+The existing health-reflection behavior is covered in test_security.py.
+"""
+
+import pytest
+
+from obsidian_vault_mcp import config, server
+
+
+def test_validate_heartbeat_disabled_returns_none(monkeypatch):
+    monkeypatch.setattr(config, "VAULT_MCP_HEARTBEAT_URL", "")
+    assert config.validate_heartbeat() is None
+
+
+def test_validate_heartbeat_valid_returns_interval(monkeypatch):
+    monkeypatch.setattr(config, "VAULT_MCP_HEARTBEAT_URL", "https://hc.example/ping/secret")
+    monkeypatch.setattr(config, "VAULT_MCP_HEARTBEAT_INTERVAL", 90)
+    assert config.validate_heartbeat() == 90
+
+
+@pytest.mark.parametrize("url", ["ftp://hc.example/x", "file:///etc/passwd", "notaurl", "http://"])
+def test_validate_heartbeat_rejects_bad_url(monkeypatch, url):
+    monkeypatch.setattr(config, "VAULT_MCP_HEARTBEAT_URL", url)
+    monkeypatch.setattr(config, "VAULT_MCP_HEARTBEAT_INTERVAL", 60)
+    with pytest.raises(ValueError):
+        config.validate_heartbeat()
+
+
+@pytest.mark.parametrize("interval", [0, -5])
+def test_validate_heartbeat_rejects_nonpositive_interval(monkeypatch, interval):
+    monkeypatch.setattr(config, "VAULT_MCP_HEARTBEAT_URL", "https://hc.example/ping")
+    monkeypatch.setattr(config, "VAULT_MCP_HEARTBEAT_INTERVAL", interval)
+    with pytest.raises(ValueError):
+        config.validate_heartbeat()
+
+
+def test_validate_heartbeat_error_never_leaks_capability_url(monkeypatch):
+    # The URL path is a secret; a validation error must not echo it.
+    secret = "https-typo://hc.example/AAAA-SECRET-TOKEN"
+    monkeypatch.setattr(config, "VAULT_MCP_HEARTBEAT_URL", secret)
+    monkeypatch.setattr(config, "VAULT_MCP_HEARTBEAT_INTERVAL", 60)
+    with pytest.raises(ValueError) as exc:
+        config.validate_heartbeat()
+    assert "SECRET" not in str(exc.value)
+
+
+def test_no_redirect_handler_refuses_redirects():
+    handler = server._NoRedirect()
+    assert handler.redirect_request("req", "fp", 302, "msg", {}, "https://evil.example") is None


### PR DESCRIPTION
Inbound backflow from today's upstream commits.

**#45 heartbeat hardening — adopted.** NoRedirect opener (no capability-URL leak via redirect), 1 KB read cap, `validate_heartbeat()` fail-closed at startup (bad URL scheme / non-positive interval aborts boot), failure path no longer logs/stores the raw exception (can contain the secret URL). The fork's richer `/health` heartbeat state is unchanged.

**#43 mount-path — intentionally skipped.** The fork serves at `/` via its own compatibility middleware + root probe; no `streamable_http_path` knob to make configurable and nothing for a path validator to guard.

Tests: `tests/test_heartbeat_hardening.py` (10 cases). Full suite 316 passed locally.