### PR TITLE
fix(audit): in-vault rejection + per-file batch status (backport #56) (v0.8.11)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,18 @@ This project follows semantic versioning. Release dates use YYYY-MM-DD.
 
 ## [Unreleased]
 
+## [v0.8.11] - 2026-06-14
+
+### Security
+- **Audit log rejected inside the vault (fail-closed).** If `VAULT_AUDIT_LOG_PATH` resolves inside `VAULT_PATH`, the server now refuses to start: a same-vault log is reachable by the vault tools (`vault_write`/`vault_delete`), which would let an authenticated caller tamper with or delete the trail. Backported from the upstream review of jimprosser/obsidian-web-mcp#56.
+
+### Fixed
+- **Batch mutations record correct per-file status.** `vault_batch_frontmatter_update` and `vault_batch_replace` now emit **one audit record per file** with that file's own `operation_status` and real before/after size+checksum. Previously a batch with per-file failures was logged as a single `success` and the list `target_path` produced null snapshots. (jimprosser/obsidian-web-mcp#56)
+- **`vault_edit(dry_run=true)` is no longer recorded as a mutation** (it writes nothing).
+
+### Tests
+- `tests/test_audit_hardening.py`: in-vault rejection, per-file batch status (frontmatter + replace), dry-run skip, and an HTTP-level test that the bearer middleware propagates the principal to the sync tool layer (the path the audit's `token_id_hash` depends on).
+
 ## [v0.8.10] - 2026-06-14
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Production-hardened fork of [`jimprosser/obsidian-web-mcp`](https://github.com/jimprosser/obsidian-web-mcp): an HTTP-based MCP server that exposes an Obsidian vault to LLM clients such as Claude, ChatGPT, and Codex over OAuth 2.0.
 
-**Latest release:** [v0.8.10](https://github.com/mleitnercom/obsidian-web-mcp/releases/tag/v0.8.10) (2026-06-14)
+**Latest release:** [v0.8.11](https://github.com/mleitnercom/obsidian-web-mcp/releases/tag/v0.8.11) (2026-06-14)
 
 ## At a Glance
 

--- a/docs/audit.md
+++ b/docs/audit.md
@@ -4,6 +4,8 @@ Back to [README](../README.md).
 
 Set `VAULT_AUDIT_LOG_PATH` to enable append-only JSON Lines audit logging. When unset, audit logging is disabled and tool behavior is unchanged.
 
+**The path must resolve outside the vault.** A log inside `VAULT_PATH` would be just another file the vault tools can reach, so an authenticated caller could overwrite it (`vault_write`) or delete it (`vault_delete`) and defeat the append-only premise. The server validates this at startup and **refuses to start (fail-closed)** if the configured path resolves inside the vault.
+
 ## Record Format
 
 Each record is one JSON object per line:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "obsidian-web-mcp"
-version = "0.8.10"
+version = "0.8.11"
 description = "Secure remote MCP server for Obsidian vaults -- access your notes from Claude, your phone, or any MCP client, anywhere"
 readme = "README.md"
 requires-python = ">=3.12"

--- a/src/obsidian_vault_mcp/audit.py
+++ b/src/obsidian_vault_mcp/audit.py
@@ -50,6 +50,9 @@ READ_OPERATIONS = {
     "vault_canvas_read",
 }
 
+# Mutations whose result reports per-file outcomes; audited one record per file.
+BATCH_OPERATIONS = {"vault_batch_replace", "vault_batch_frontmatter_update"}
+
 _AUDIT_WINDOW = timedelta(hours=24)
 _audit_write_events: deque[dict[str, Any]] = deque()
 
@@ -71,6 +74,24 @@ def should_audit_operation(operation: str) -> bool:
 
 def _audit_path() -> Path:
     return Path(config.VAULT_AUDIT_LOG_PATH).expanduser()
+
+
+def audit_path_inside_vault() -> bool:
+    """True when the configured audit log resolves inside the vault.
+
+    A same-vault log is reachable by the vault tools (resolve_vault_path only blocks
+    traversal and dotfiles), so an authenticated caller could overwrite it via vault_write
+    or relocate it via vault_delete -- defeating the append-only integrity premise. Such a
+    path is rejected at startup (see server.main). Mirrors upstream jimprosser#56.
+    """
+    if not audit_enabled():
+        return False
+    try:
+        log = _audit_path().resolve()
+        vault = config.VAULT_PATH.resolve()
+    except OSError:
+        return False
+    return log == vault or vault in log.parents
 
 
 def _now_utc() -> datetime:

--- a/src/obsidian_vault_mcp/server.py
+++ b/src/obsidian_vault_mcp/server.py
@@ -23,8 +23,10 @@ from pydantic import Field
 
 from . import config
 from .audit import (
+    BATCH_OPERATIONS,
     MUTATION_OPERATIONS,
     audit_health_payload,
+    audit_path_inside_vault,
     before_target_path,
     build_audit_record,
     infer_target_path,
@@ -165,6 +167,41 @@ def _log_oauth_runtime_summary() -> None:
         )
 
 
+def _emit_batch_audit_records(name: str, before_map: dict[str, Any], parsed_result: dict[str, Any]) -> None:
+    """Emit one audit record per file for a batch mutation, with correct per-file status.
+
+    The batch tools report per-file outcomes in ``results`` (some files can fail while the
+    call as a whole "succeeds"), so a single record would both hide partial failures and
+    lose per-file snapshots. before_map holds the pre-call snapshots keyed by path. Mirrors
+    upstream jimprosser#56.
+    """
+    items = parsed_result.get("results")
+    if not isinstance(items, list) or not items:
+        write_audit_record(build_audit_record(
+            operation=name,
+            target_path=list(before_map) or None,
+            operation_status="error" if "error" in parsed_result else "success",
+            error=parsed_result.get("error"),
+        ))
+        return
+    for item in items:
+        if not isinstance(item, dict):
+            continue
+        path = item.get("path")
+        item_error = item.get("error")
+        item_status = "error" if item_error else "success"
+        before = before_map.get(path) if isinstance(path, str) else None
+        after = snapshot_path(path) if (item_status == "success" and isinstance(path, str)) else None
+        write_audit_record(build_audit_record(
+            operation=name,
+            target_path=path,
+            before=before,
+            after=after,
+            operation_status=item_status,
+            error=item_error,
+        ))
+
+
 def _run_logged_tool(name: str, func: Callable[[], str], **context: Any) -> str:
     """Run one MCP tool call with consistent start/end/error logging."""
     started = time.monotonic()
@@ -172,6 +209,12 @@ def _run_logged_tool(name: str, func: Callable[[], str], **context: Any) -> str:
     audit_after = None
     is_mutation = name in MUTATION_OPERATIONS
     should_audit = should_audit_operation(name)
+    # Batch mutations are audited per file; snapshot each target BEFORE the writes run.
+    batch_before_map: dict[str, Any] = {}
+    if should_audit and name in BATCH_OPERATIONS:
+        batch_before_map = {
+            p: snapshot_path(p) for p in (context.get("paths") or []) if isinstance(p, str) and p
+        }
     if name in MUTATION_OPERATIONS:
         audit_before_path = before_target_path(name, context)
         audit_before = snapshot_path(audit_before_path)
@@ -228,6 +271,13 @@ def _run_logged_tool(name: str, func: Callable[[], str], **context: Any) -> str:
                 parsed_result = payload
         except Exception:
             parsed_result = {}
+        if name in BATCH_OPERATIONS:
+            _emit_batch_audit_records(name, batch_before_map, parsed_result)
+            if is_mutation:
+                flush_post_write_hooks(None)
+            else:
+                clear_post_write_hooks()
+            return result
         target_path = infer_target_path(name, context, parsed_result)
         operation_status = "error" if "error" in parsed_result else "success"
         if is_mutation:
@@ -944,6 +994,7 @@ def vault_batch_frontmatter_update(updates: list[dict]) -> str:
         "vault_batch_frontmatter_update",
         lambda: _vault_batch_frontmatter_update(inp.updates),
         updates=len(inp.updates),
+        paths=[u.get("path") for u in inp.updates if isinstance(u, dict) and u.get("path")],
     )
 
 
@@ -962,6 +1013,7 @@ def vault_batch_replace(updates: list[dict]) -> str:
         "vault_batch_replace",
         lambda: _vault_batch_replace(inp.updates),
         updates=len(inp.updates),
+        paths=[u.get("path") for u in inp.updates if isinstance(u, dict) and u.get("path")],
     )
 
 
@@ -1001,6 +1053,9 @@ def vault_edit(path: str, edits: list[dict], dry_run: bool = False) -> str:
     limited = _tool_rate_limit_error("write", config.RATE_LIMIT_WRITE)
     if limited is not None:
         return limited
+    if inp.dry_run:
+        # A dry run writes nothing; don't record it as a mutation. (#56 non-blocking)
+        return _vault_edit(inp.path, [edit.model_dump() for edit in inp.edits], inp.dry_run)
     return _run_logged_tool(
         "vault_edit",
         lambda: _vault_edit(inp.path, [edit.model_dump() for edit in inp.edits], inp.dry_run),
@@ -1621,6 +1676,15 @@ def main():
 
     if not VAULT_MCP_TOKEN:
         logger.warning("VAULT_MCP_TOKEN is not set -- auth will reject all requests")
+
+    # Fail CLOSED on an audit log that resolves inside the vault: the vault tools could
+    # then overwrite or delete it, defeating the append-only integrity premise. (#56)
+    if audit_path_inside_vault():
+        logger.error(
+            f"VAULT_AUDIT_LOG_PATH resolves inside the vault ({config.VAULT_AUDIT_LOG_PATH}); "
+            "the vault tools could rewrite it. Choose a path outside VAULT_PATH."
+        )
+        sys.exit(1)
 
     # Fail CLOSED on a misconfigured heartbeat (bad URL scheme / non-positive interval)
     # rather than booting a server that silently never pings. (Hardening from upstream #45.)

--- a/tests/test_audit_hardening.py
+++ b/tests/test_audit_hardening.py
@@ -1,0 +1,122 @@
+"""Audit hardening backported from upstream review jimprosser/obsidian-web-mcp#56:
+
+  #2 reject an audit log that resolves inside the vault (it would be tamperable),
+  #3 batch mutations emit one record per file with correct per-file status + snapshots,
+  #4 the BearerAuthMiddleware -> sync tool principal propagation is exercised over HTTP,
+  and a dry-run edit is no longer recorded as a mutation.
+"""
+
+import json
+
+import pytest
+
+from obsidian_vault_mcp import audit, config, server
+from obsidian_vault_mcp.rate_limit import (
+    current_auth_principal,
+    reset_current_auth_principal,
+    reset_current_request_metadata,
+    set_current_auth_principal,
+    set_current_request_metadata,
+)
+
+PRINCIPAL = "audit-hardening-token"
+
+
+@pytest.fixture
+def audit_log(vault_dir, tmp_path, monkeypatch):
+    log_path = tmp_path / "audit" / "log.jsonl"
+    monkeypatch.setattr(config, "VAULT_AUDIT_LOG_PATH", str(log_path))
+    monkeypatch.setattr(config, "VAULT_AUDIT_LOG_INCLUDE_READS", False)
+    p = set_current_auth_principal(PRINCIPAL)
+    m = set_current_request_metadata({"client_family": "pytest", "request_id": "req-1"})
+    yield log_path
+    reset_current_request_metadata(m)
+    reset_current_auth_principal(p)
+
+
+def _records(path):
+    if not path.exists():
+        return []
+    return [json.loads(line) for line in path.read_text(encoding="utf-8").splitlines() if line.strip()]
+
+
+# --- #2: in-vault audit log rejected ---
+
+def test_audit_path_inside_vault_detected(vault_dir, monkeypatch):
+    monkeypatch.setattr(config, "VAULT_AUDIT_LOG_PATH", str(vault_dir / "audit.jsonl"))
+    assert audit.audit_path_inside_vault() is True
+    monkeypatch.setattr(config, "VAULT_AUDIT_LOG_PATH", str(vault_dir / "subfolder" / "a.jsonl"))
+    assert audit.audit_path_inside_vault() is True
+
+
+def test_audit_path_outside_vault_ok(vault_dir, tmp_path, monkeypatch):
+    # tmp_path is the vault's parent, so a sibling dir is outside the vault.
+    monkeypatch.setattr(config, "VAULT_AUDIT_LOG_PATH", str(tmp_path / "outside" / "a.jsonl"))
+    assert audit.audit_path_inside_vault() is False
+
+
+# --- #3: batch mutations record per-file status, not one thin record ---
+
+def test_batch_frontmatter_one_record_per_file(audit_log):
+    server.vault_write("a.md", "---\nx: 1\n---\nbody")
+    updates = [
+        {"path": "a.md", "fields": {"status": "done"}},
+        {"path": "missing.md", "fields": {"status": "done"}},
+    ]
+    server.vault_batch_frontmatter_update(updates)
+    recs = [r for r in _records(audit_log) if r["operation"] == "vault_batch_frontmatter_update"]
+    assert len(recs) == 2                       # one per file, not one for the call
+    by_path = {r["target_path"]: r for r in recs}
+    assert by_path["a.md"]["operation_status"] == "success"
+    assert by_path["a.md"]["checksum_after"] is not None    # real snapshot, not null
+    assert by_path["missing.md"]["operation_status"] == "error"   # partial failure surfaced
+    assert by_path["missing.md"]["error"]
+
+
+def test_batch_replace_one_record_per_file(audit_log):
+    server.vault_write("r.md", "hello world")
+    updates = [
+        {"path": "r.md", "old_str": "hello", "new_str": "hi"},
+        {"path": "gone.md", "old_str": "x", "new_str": "y"},
+    ]
+    server.vault_batch_replace(updates)
+    recs = [r for r in _records(audit_log) if r["operation"] == "vault_batch_replace"]
+    assert len(recs) == 2
+    by_path = {r["target_path"]: r for r in recs}
+    assert by_path["r.md"]["operation_status"] == "success"
+    assert by_path["gone.md"]["operation_status"] == "error"
+
+
+# --- dry-run edit is not recorded as a mutation ---
+
+def test_dry_run_edit_not_audited(audit_log):
+    server.vault_write("e.md", "alpha beta")
+    before = len(_records(audit_log))
+    server.vault_edit("e.md", [{"old_text": "alpha", "new_text": "ALPHA"}], dry_run=True)
+    assert len(_records(audit_log)) == before          # dry run logged nothing
+    server.vault_edit("e.md", [{"old_text": "alpha", "new_text": "ALPHA"}])
+    assert len(_records(audit_log)) == before + 1       # the real edit IS audited
+
+
+# --- #4: principal reaches the sync tool layer through the real middleware ---
+
+def test_principal_propagates_to_sync_handler(monkeypatch):
+    from starlette.applications import Starlette
+    from starlette.responses import JSONResponse
+    from starlette.routing import Route
+    from starlette.testclient import TestClient
+
+    from obsidian_vault_mcp import auth as auth_module
+
+    monkeypatch.setattr(auth_module, "VAULT_MCP_TOKEN", "secret-token")
+
+    def sync_probe(request):  # sync on purpose: mirrors how FastMCP runs vault_* tools
+        return JSONResponse({"principal": current_auth_principal()})
+
+    app = Starlette(routes=[Route("/probe", sync_probe)])
+    app.add_middleware(auth_module.BearerAuthMiddleware)
+    client = TestClient(app)
+
+    r = client.get("/probe", headers={"Authorization": "Bearer secret-token", "User-Agent": "p/1"})
+    assert r.status_code == 200, r.text
+    assert r.json()["principal"] == "secret-token"   # null here => token_id_hash null in prod

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -730,7 +730,7 @@ def test_audit_log_records_mutation_operations(vault_dir, monkeypatch, tmp_path)
     run_and_assert(
         "vault_batch_replace",
         lambda: server.vault_batch_replace([{"path": "audit/batch-replace.md", "old_str": "alpha", "new_str": "beta"}]),
-        ["audit/batch-replace.md"],
+        "audit/batch-replace.md",   # batch now records one scalar-target record per file (#56)
     )
 
     vault_write("audit/move-source.md", "move\n")
@@ -750,7 +750,7 @@ def test_audit_log_records_mutation_operations(vault_dir, monkeypatch, tmp_path)
     run_and_assert(
         "vault_batch_frontmatter_update",
         lambda: server.vault_batch_frontmatter_update([{"path": "audit/frontmatter.md", "fields": {"status": "new"}}]),
-        ["audit/frontmatter.md"],
+        "audit/frontmatter.md",   # batch now records one scalar-target record per file (#56)
     )
 
     source = tmp_path / "source.pdf"


### PR DESCRIPTION
Backports the substantive findings from the upstream review of [jimprosser#56](https://github.com/jimprosser/obsidian-web-mcp/pull/56) into the fork's own audit feature.

- **In-vault rejection (fail-closed):** `VAULT_AUDIT_LOG_PATH` resolving inside `VAULT_PATH` is rejected at startup (a same-vault log is tamperable via `vault_write`/`vault_delete`).
- **Per-file batch status:** `vault_batch_frontmatter_update` and `vault_batch_replace` emit one record per file with that file's own `operation_status` + real before/after snapshots, instead of a single record that hid partial failures and nulled list-target snapshots.
- **dry-run edits not audited** as mutations.

Not backported: #1 (/health disclosure) — the fork already gates detailed health behind the loopback / `VAULT_HEALTH_ALLOW_REMOTE_DETAILS` check, so remote callers only get the minimal payload.

Tests: `tests/test_audit_hardening.py` + updated batch assertions in `test_tools.py`. Full suite 322 passed locally.