### PR TITLE
refactor: converge serialization onto upstream's module (#9) (v0.8.12)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ This project follows semantic versioning. Release dates use YYYY-MM-DD.
 
 ## [Unreleased]
 
+## [v0.8.12] - 2026-06-15
+
+### Changed
+- **Serialization converged onto upstream's module (#9).** Added `serialization.py` (byte-identical to `jimprosser/obsidian-web-mcp`'s) and routed `vault_json_dumps` through it. Tool responses now use compact separators like upstream (`{"a":1}` rather than `{"a": 1}`) — token-efficient and semantically identical JSON; the date/datetime encoder and the non-UTF-8/surrogate fallback are unchanged. `vault_json_dumps` remains a thin alias; the canonical name is `serialization.dumps`. This is the keystone for the planned re-platform: shared primitives now match upstream, so feature modules become portable onto stock `upstream/main`.
+
 ## [v0.8.11] - 2026-06-14
 
 ### Security

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Production-hardened fork of [`jimprosser/obsidian-web-mcp`](https://github.com/jimprosser/obsidian-web-mcp): an HTTP-based MCP server that exposes an Obsidian vault to LLM clients such as Claude, ChatGPT, and Codex over OAuth 2.0.
 
-**Latest release:** [v0.8.11](https://github.com/mleitnercom/obsidian-web-mcp/releases/tag/v0.8.11) (2026-06-14)
+**Latest release:** [v0.8.12](https://github.com/mleitnercom/obsidian-web-mcp/releases/tag/v0.8.12) (2026-06-15)
 
 ## At a Glance
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "obsidian-web-mcp"
-version = "0.8.11"
+version = "0.8.12"
 description = "Secure remote MCP server for Obsidian vaults -- access your notes from Claude, your phone, or any MCP client, anywhere"
 readme = "README.md"
 requires-python = ">=3.12"

--- a/src/obsidian_vault_mcp/serialization.py
+++ b/src/obsidian_vault_mcp/serialization.py
@@ -1,0 +1,58 @@
+"""JSON serialization helpers for the Obsidian vault MCP server.
+
+python-frontmatter parses YAML date fields into Python date/datetime objects,
+which the stdlib json encoder can't handle. This module provides a drop-in
+replacement for json.dumps that serializes those types as ISO 8601 strings (#5).
+
+It is also the single place that controls how each tool serializes its result
+payload, so all tool modules should route through dumps() rather than calling
+json.dumps directly. Two defaults make responses token-efficient:
+
+- ensure_ascii=False: non-ASCII text (Korean, Japanese, emoji, etc.) is emitted
+  verbatim as UTF-8 instead of \\uXXXX escapes. The default True roughly doubled
+  the size of a CJK-heavy response (and up to tripled it for non-BMP emoji, which
+  escape to 12-character surrogate pairs), and produced escaped paths that could
+  fail to round-trip. The decoded object is identical either way; ASCII-only
+  responses are unaffected.
+- compact separators: drops the spaces after ',' and ':' that json.dumps inserts
+  by default. Responses are consumed by a model, not read raw, so that whitespace
+  is pure overhead.
+
+Callers may override either default by passing the keyword explicitly.
+"""
+
+import json
+import logging
+from datetime import date, datetime
+
+logger = logging.getLogger(__name__)
+
+
+class _VaultEncoder(json.JSONEncoder):
+    def default(self, obj):
+        if isinstance(obj, (datetime, date)):
+            return obj.isoformat()
+        return super().default(obj)
+
+
+def dumps(obj, **kwargs) -> str:
+    """json.dumps with date/datetime support and token-efficient defaults."""
+    kwargs.setdefault("ensure_ascii", False)
+    kwargs.setdefault("separators", (",", ":"))
+    result = json.dumps(obj, cls=_VaultEncoder, **kwargs)
+    if not kwargs["ensure_ascii"]:
+        # A filename that is not valid UTF-8 reaches us as a lone surrogate
+        # (os.fsdecode uses surrogateescape). json.dumps accepts it, but the
+        # resulting string then raises UnicodeEncodeError when the transport
+        # encodes it to UTF-8 -- outside any tool's error handling. Fall back to
+        # escaped output so one odd filename cannot crash an otherwise fine
+        # response.
+        try:
+            result.encode("utf-8")
+        except UnicodeEncodeError:
+            logger.warning(
+                "Response contains a non-UTF-8 (surrogate) string, likely from a "
+                "filename that is not valid UTF-8; falling back to escaped output"
+            )
+            result = json.dumps(obj, cls=_VaultEncoder, **{**kwargs, "ensure_ascii": True})
+    return result

--- a/src/obsidian_vault_mcp/vault.py
+++ b/src/obsidian_vault_mcp/vault.py
@@ -13,6 +13,10 @@ from datetime import date, datetime, timezone
 from pathlib import Path
 
 from . import config
+# Converged to upstream's serialization module (#9). vault_json_dumps is kept as a
+# thin alias so existing call sites work unchanged; the canonical name is
+# serialization.dumps (call-site rename happens at the Phase-2 re-fork).
+from .serialization import dumps as vault_json_dumps
 
 UNSUPPORTED_BINARY_EXTENSIONS = frozenset({
     ".7z",
@@ -43,44 +47,7 @@ UNSUPPORTED_BINARY_EXTENSIONS = frozenset({
 })
 
 
-class _DateAwareEncoder(json.JSONEncoder):
-    """JSON encoder that serialises date/datetime objects to ISO 8601 strings.
-
-    PyYAML's safe_load converts bare YAML dates (e.g. ``created: 2026-04-05``)
-    into ``datetime.date`` objects.  The stdlib ``json`` module cannot handle
-    these, so we provide a thin wrapper that converts them on the fly.
-    """
-
-    def default(self, obj: object) -> str:
-        if isinstance(obj, (date, datetime)):
-            return obj.isoformat()
-        return super().default(obj)
-
-
-def vault_json_dumps(obj: object, **kwargs) -> str:
-    """``json.dumps`` replacement that handles ``datetime.date`` values and
-    emits non-ASCII text as UTF-8 instead of ``\\uXXXX`` escapes.
-
-    ``ensure_ascii`` defaults to ``False`` so tool responses stay compact for
-    non-ASCII vaults and round-trip non-ASCII paths/content verbatim. Callers
-    may still override it (e.g. pass ``ensure_ascii=True`` for ASCII-only
-    on-disk state).
-
-    Guard: a vault file whose on-disk name is not valid UTF-8 reaches Python as
-    a lone surrogate (via ``surrogateescape``). With ``ensure_ascii=False`` that
-    surrogate is emitted verbatim and the MCP transport then fails to UTF-8
-    encode the *whole* response. We verify encodability and fall back to escaped
-    output for that one response, so a single odd filename cannot take down an
-    otherwise valid payload.
-    """
-    kwargs.setdefault("ensure_ascii", False)
-    result = json.dumps(obj, cls=_DateAwareEncoder, **kwargs)
-    if not kwargs["ensure_ascii"]:
-        try:
-            result.encode("utf-8")
-        except UnicodeEncodeError:
-            result = json.dumps(obj, cls=_DateAwareEncoder, **{**kwargs, "ensure_ascii": True})
-    return result
+# vault_json_dumps is now imported from .serialization (see top of file, #9).
 
 
 class OcrError(RuntimeError):


### PR DESCRIPTION
Phase-2 re-platform keystone. Adds `serialization.py` (byte-identical to upstream's) and routes `vault_json_dumps` through it as a thin alias. Tool responses now use upstream's compact separators (`{"a":1}`) — token-efficient, semantically identical JSON; date encoder + non-UTF-8 surrogate fallback unchanged. Full suite green (322 passed), no test changes needed. Canonical name is `serialization.dumps`; `vault_json_dumps` stays as a transitional alias (call-site rename happens at the re-fork).