### PR TITLE
security(import): SSRF-harden vault_import_url (v0.8.13)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,18 @@ This project follows semantic versioning. Release dates use YYYY-MM-DD.
 
 ## [Unreleased]
 
+## [v0.8.13] - 2026-06-16
+
+### Security
+- **`vault_import_url` is now SSRF-hardened.** The previous guard resolved the hostname and checked the IP, then handed the URL to `urlopen` — defeatable two ways, both now closed:
+  - **DNS rebinding / TOCTOU.** The validator and `urlopen` resolved the name independently, so a malicious DNS could return a public IP to the check and a private IP (e.g. `169.254.169.254`, loopback) to the connect. The new `url_fetch.fetch_url` resolves **once** and pins the connection to the validated IP, preserving the original `Host` header and TLS SNI/certificate hostname.
+  - **Redirects.** `urlopen` auto-followed `30x` and only the first URL was validated, so a public URL could redirect to an internal one. Redirects are no longer auto-followed; **every hop is re-validated and re-pinned** against a hop budget (`VAULT_IMPORT_URL_MAX_REDIRECTS`, default 5).
+  - Defense in depth: public-IP-only by default (`is_global`, IPv4-mapped IPv6 unwrapped so `::ffff:169.254.169.254` cannot smuggle a target), scheme allowlist, and a port allowlist (`VAULT_IMPORT_URL_ALLOWED_PORTS`, default `80,443`). `VAULT_IMPORT_URL_ALLOW_PRIVATE=true` remains the explicit opt-in for trusted single-user deployments.
+- New module `obsidian_vault_mcp/url_fetch.py` holds the hardened fetcher; it is mirrored by the `obsidian-vault-mcp-ext` ImportExtension so the two stay in sync.
+
+### Tests
+- `tests/test_url_fetch.py`: rebinding-closed (resolve once + pin), redirect-to-metadata rejected, redirect-budget, IP classification, scheme/port guards, size cap. Existing `vault_import_url` tests now stub the `fetch_url` seam.
+
 ## [v0.8.12] - 2026-06-15
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Production-hardened fork of [`jimprosser/obsidian-web-mcp`](https://github.com/jimprosser/obsidian-web-mcp): an HTTP-based MCP server that exposes an Obsidian vault to LLM clients such as Claude, ChatGPT, and Codex over OAuth 2.0.
 
-**Latest release:** [v0.8.12](https://github.com/mleitnercom/obsidian-web-mcp/releases/tag/v0.8.12) (2026-06-15)
+**Latest release:** [v0.8.13](https://github.com/mleitnercom/obsidian-web-mcp/releases/tag/v0.8.13) (2026-06-16)
 
 ## At a Glance
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "obsidian-web-mcp"
-version = "0.8.12"
+version = "0.8.13"
 description = "Secure remote MCP server for Obsidian vaults -- access your notes from Claude, your phone, or any MCP client, anywhere"
 readme = "README.md"
 requires-python = ">=3.12"

--- a/src/obsidian_vault_mcp/config.py
+++ b/src/obsidian_vault_mcp/config.py
@@ -253,6 +253,28 @@ MAX_CONTENT_SIZE = _env_int("VAULT_MAX_CONTENT_SIZE", 1_000_000)
 MAX_BINARY_SIZE = _env_int("VAULT_MAX_BINARY_SIZE", 10 * 1024 * 1024)
 IMPORT_URL_TIMEOUT_SECONDS = _env_int("VAULT_IMPORT_URL_TIMEOUT_SECONDS", 30)
 IMPORT_URL_ALLOW_PRIVATE = _env_bool("VAULT_IMPORT_URL_ALLOW_PRIVATE", False)
+IMPORT_URL_MAX_REDIRECTS = _env_int("VAULT_IMPORT_URL_MAX_REDIRECTS", 5)
+
+
+def _env_int_set(name: str, default: set[int]) -> set[int]:
+    """Parse a comma-separated set of ints (e.g. allowed ports) with a safe fallback."""
+    raw = os.environ.get(name, "").strip()
+    if not raw:
+        return set(default)
+    out: set[int] = set()
+    for part in raw.split(","):
+        part = part.strip()
+        if not part:
+            continue
+        try:
+            out.add(int(part))
+        except ValueError:
+            continue
+    return out or set(default)
+
+
+# Ports the URL importer may connect to (SSRF defense in depth). Default http/https.
+IMPORT_URL_ALLOWED_PORTS = _env_int_set("VAULT_IMPORT_URL_ALLOWED_PORTS", {80, 443})
 MAX_BATCH_SIZE = _env_int("VAULT_MAX_BATCH_SIZE", 20)
 MAX_SEARCH_RESULTS = _env_int("VAULT_MAX_SEARCH_RESULTS", 50)
 MAX_FRONTMATTER_SEARCH_RESULTS = _env_int("VAULT_MAX_FRONTMATTER_SEARCH_RESULTS", 500)

--- a/src/obsidian_vault_mcp/tools/write.py
+++ b/src/obsidian_vault_mcp/tools/write.py
@@ -5,21 +5,18 @@ import binascii
 import difflib
 import hashlib
 import hmac
-import ipaddress
 import json
 import logging
 import shutil
-import socket
 import time
 import uuid
 from pathlib import Path
-from urllib.error import HTTPError, URLError
-from urllib.parse import urlencode, urlparse
-from urllib.request import Request, urlopen
+from urllib.parse import urlencode
 
 from .. import config
 from .. import frontmatter_io
 from ..hooks import fire_post_write
+from ..url_fetch import ImportFetchError, ImportSecurityError, fetch_url
 from ..vault import (
     read_file,
     resolve_vault_path,
@@ -496,25 +493,6 @@ def commit_direct_upload(
         return {"error": str(e), "upload_id": upload_id}, 500
 
 
-def _validate_import_url(url: str) -> None:
-    parsed = urlparse(url)
-    if parsed.scheme not in {"http", "https"}:
-        raise ValueError("Only http and https URLs are supported")
-    if not parsed.hostname:
-        raise ValueError("URL must include a hostname")
-    if config.IMPORT_URL_ALLOW_PRIVATE:
-        return
-    try:
-        infos = socket.getaddrinfo(parsed.hostname, parsed.port or (443 if parsed.scheme == "https" else 80), type=socket.SOCK_STREAM)
-    except socket.gaierror as exc:
-        raise ValueError(f"Could not resolve URL hostname: {parsed.hostname}") from exc
-    for info in infos:
-        address = info[4][0]
-        ip = ipaddress.ip_address(address)
-        if ip.is_private or ip.is_loopback or ip.is_link_local or ip.is_reserved or ip.is_multicast:
-            raise ValueError("URL resolves to a private or local address; set VAULT_IMPORT_URL_ALLOW_PRIVATE=true to opt in")
-
-
 def vault_write(path: str, content: str, create_dirs: bool = True, merge_frontmatter: bool = False) -> str:
     """Write a file to the vault, optionally merging frontmatter with existing content."""
     try:
@@ -636,10 +614,16 @@ def vault_import_url(
     create_dirs: bool = True,
     expected_sha256: str | None = None,
 ) -> str:
-    """Import an allowed binary file by letting the server download it from a URL."""
+    """Import an allowed binary file by letting the server download it from a URL.
+
+    The download is SSRF-hardened (see ``url_fetch``): the host is resolved once and the
+    connection is pinned to the validated IP (no DNS-rebinding window), every redirect hop is
+    re-validated and re-pinned, non-public targets are denied unless
+    ``VAULT_IMPORT_URL_ALLOW_PRIVATE`` is set, the scheme/port are allowlisted, and the size is
+    capped on the actual read.
+    """
     try:
         resolved = _validate_binary_target(path, media_type)
-        _validate_import_url(url)
         if resolved.exists() and not overwrite:
             return vault_json_dumps(
                 {
@@ -648,34 +632,27 @@ def vault_import_url(
                     "media_type": media_type,
                 }
             )
-        request = Request(url, headers={"User-Agent": "obsidian-web-mcp/attachment-import"})
-        data = bytearray()
-        with urlopen(request, timeout=config.IMPORT_URL_TIMEOUT_SECONDS) as response:
-            content_type = (response.headers.get("content-type") or "").split(";", 1)[0].strip().lower()
-            if content_type and content_type != media_type:
-                return vault_json_dumps(
-                    {
-                        "error": f"URL content-type '{content_type}' does not match requested media_type '{media_type}'",
-                        "path": path,
-                        "media_type": media_type,
-                        "url": url,
-                    }
-                )
-            while True:
-                chunk = response.read(1024 * 1024)
-                if not chunk:
-                    break
-                data.extend(chunk)
-                if len(data) > config.MAX_BINARY_SIZE:
-                    return vault_json_dumps(
-                        {
-                            "error": f"Downloaded content exceeds limit of {config.MAX_BINARY_SIZE} bytes",
-                            "path": path,
-                            "media_type": media_type,
-                            "url": url,
-                        }
-                    )
-        content = bytes(data)
+        try:
+            content_type, content = fetch_url(
+                url,
+                allow_private=config.IMPORT_URL_ALLOW_PRIVATE,
+                allowed_ports=config.IMPORT_URL_ALLOWED_PORTS,
+                max_bytes=config.MAX_BINARY_SIZE,
+                max_redirects=config.IMPORT_URL_MAX_REDIRECTS,
+                timeout=config.IMPORT_URL_TIMEOUT_SECONDS,
+            )
+        except (ImportSecurityError, ImportFetchError) as e:
+            return vault_json_dumps({"error": str(e), "path": path, "media_type": media_type, "url": url})
+
+        if content_type and content_type != media_type:
+            return vault_json_dumps(
+                {
+                    "error": f"URL content-type '{content_type}' does not match requested media_type '{media_type}'",
+                    "path": path,
+                    "media_type": media_type,
+                    "url": url,
+                }
+            )
         actual_sha256 = _sha256_bytes(content)
         if expected_sha256 and actual_sha256.lower() != expected_sha256.lower():
             return vault_json_dumps(
@@ -698,8 +675,6 @@ def vault_import_url(
                 "source_url": url,
             }
         )
-    except (HTTPError, URLError, TimeoutError) as e:
-        return vault_json_dumps({"error": str(e), "path": path, "media_type": media_type, "url": url})
     except ValueError as e:
         return vault_json_dumps({"error": str(e), "path": path, "media_type": media_type, "url": url})
     except Exception as e:

--- a/src/obsidian_vault_mcp/url_fetch.py
+++ b/src/obsidian_vault_mcp/url_fetch.py
@@ -1,0 +1,167 @@
+"""SSRF-hardened HTTP(S) fetcher for ``vault_import_url``.
+
+A naive "resolve the hostname, check the IP, then hand the URL to urllib" guard is defeatable
+two ways, both closed here:
+
+1. DNS rebinding / TOCTOU. The validation resolves the name and the HTTP client resolves it
+   again independently; a malicious DNS returns a public IP to the check and a private IP
+   (169.254.169.254, 127.0.0.1) to the connect. Closed by resolving exactly once and *pinning*
+   the connection to the validated IP, while preserving the original Host header and TLS
+   SNI/cert hostname.
+
+2. Redirects. ``urlopen`` follows 30x automatically and only the first URL is validated, so a
+   public URL can redirect to an internal one. Closed by disabling auto-redirects and
+   re-validating + re-pinning every hop, with a hop budget.
+
+Defense in depth: scheme allowlist (http/https), port allowlist, public-IP-only by default
+(``is_global``, IPv4-mapped IPv6 unwrapped), and a hard byte cap on the actual read.
+
+stdlib only. This module is mirrored by the obsidian-vault-mcp-ext ImportExtension so the
+hardening stays in sync between fork and extension.
+"""
+
+import http.client
+import ipaddress
+import socket
+import ssl
+from urllib.parse import urljoin, urlparse
+
+_REDIRECT_CODES = {301, 302, 303, 307, 308}
+_DEFAULT_PORTS = {"http": 80, "https": 443}
+
+
+class ImportSecurityError(Exception):
+    """Raised when a URL (or a redirect hop) is rejected by the SSRF guards."""
+
+
+class ImportFetchError(Exception):
+    """Raised on a transport/protocol failure or a non-success status."""
+
+
+def _ip_is_public(ip: ipaddress._BaseAddress) -> bool:
+    """Positive allowlist: only globally-routable unicast addresses pass.
+
+    IPv4-mapped IPv6 is unwrapped so ``::ffff:169.254.169.254`` cannot smuggle a link-local
+    target past the check."""
+    if isinstance(ip, ipaddress.IPv6Address) and ip.ipv4_mapped is not None:
+        ip = ip.ipv4_mapped
+    return bool(ip.is_global) and not ip.is_multicast
+
+
+def _resolve_and_pin(host: str, port: int, allow_private: bool) -> tuple[int, str]:
+    """Resolve the host ONCE, validate EVERY returned address, return (family, ip) to pin."""
+    try:
+        infos = socket.getaddrinfo(host, port, type=socket.SOCK_STREAM)
+    except socket.gaierror as exc:
+        raise ImportFetchError(f"Could not resolve hostname: {host}") from exc
+    if not infos:
+        raise ImportFetchError(f"Could not resolve hostname: {host}")
+    pinned: tuple[int, str] | None = None
+    for family, _type, _proto, _canon, sockaddr in infos:
+        ip_str = sockaddr[0]
+        if not allow_private:
+            ip = ipaddress.ip_address(ip_str)
+            if not _ip_is_public(ip):
+                raise ImportSecurityError(
+                    f"URL resolves to a non-public address ({ip_str}); set "
+                    "VAULT_IMPORT_URL_ALLOW_PRIVATE=true to opt in"
+                )
+        if pinned is None:
+            pinned = (family, ip_str)
+    assert pinned is not None
+    return pinned
+
+
+def _validate_url(url: str, allowed_ports: set[int]) -> tuple[str, str, int]:
+    """Validate scheme/host/port of one URL (or hop). Returns (scheme, host, port)."""
+    parsed = urlparse(url)
+    scheme = (parsed.scheme or "").lower()
+    if scheme not in ("http", "https"):
+        raise ImportSecurityError(f"Only http and https URLs are supported (got {scheme!r})")
+    host = parsed.hostname
+    if not host:
+        raise ImportSecurityError("URL must include a hostname")
+    port = parsed.port or _DEFAULT_PORTS[scheme]
+    if port not in allowed_ports:
+        raise ImportSecurityError(
+            f"Port {port} is not in the allowed import ports {sorted(allowed_ports)}"
+        )
+    return scheme, host, port
+
+
+def _open_connection(
+    scheme: str, host: str, pinned_ip: str, port: int, timeout: float
+) -> http.client.HTTPConnection:
+    """Connect to the pinned IP but speak to the original host (Host header + TLS SNI/cert)."""
+    if scheme == "https":
+        context = ssl.create_default_context()
+
+        class _PinnedHTTPSConnection(http.client.HTTPSConnection):
+            def connect(self_inner):  # noqa: N805
+                sock = socket.create_connection((pinned_ip, port), timeout)
+                self_inner.sock = context.wrap_socket(sock, server_hostname=host)
+
+        return _PinnedHTTPSConnection(host, port, timeout=timeout)
+
+    class _PinnedHTTPConnection(http.client.HTTPConnection):
+        def connect(self_inner):  # noqa: N805
+            self_inner.sock = socket.create_connection((pinned_ip, port), timeout)
+
+    return _PinnedHTTPConnection(host, port, timeout=timeout)
+
+
+def _read_capped(response, max_bytes: int) -> bytes:
+    """Read the body in chunks, raising once the cap is exceeded (do not trust headers)."""
+    data = bytearray()
+    while True:
+        chunk = response.read(1024 * 1024)
+        if not chunk:
+            break
+        data.extend(chunk)
+        if len(data) > max_bytes:
+            raise ImportFetchError(f"Downloaded content exceeds limit of {max_bytes} bytes")
+    return bytes(data)
+
+
+def fetch_url(
+    url: str,
+    *,
+    allow_private: bool,
+    allowed_ports: set[int],
+    max_bytes: int,
+    max_redirects: int,
+    timeout: float,
+    user_agent: str = "obsidian-web-mcp/attachment-import",
+) -> tuple[str | None, bytes]:
+    """Fetch a URL with full SSRF hardening. Returns (content_type, body_bytes)."""
+    current = url
+    for _hop in range(max_redirects + 1):
+        scheme, host, port = _validate_url(current, allowed_ports)
+        _family, pinned_ip = _resolve_and_pin(host, port, allow_private)
+        conn = _open_connection(scheme, host, pinned_ip, port, timeout)
+        try:
+            parsed = urlparse(current)
+            target = parsed.path or "/"
+            if parsed.query:
+                target = f"{target}?{parsed.query}"
+            conn.putrequest("GET", target, skip_accept_encoding=True)
+            conn.putheader("User-Agent", user_agent)
+            conn.putheader("Accept", "*/*")
+            conn.endheaders()
+            response = conn.getresponse()
+            status = response.status
+            if status in _REDIRECT_CODES:
+                location = response.headers.get("Location")
+                response.read()
+                if not location:
+                    raise ImportFetchError(f"Redirect {status} without a Location header")
+                current = urljoin(current, location)
+                continue
+            if status != 200:
+                raise ImportFetchError(f"URL returned HTTP {status}")
+            content_type = (response.headers.get("Content-Type") or "").split(";", 1)[0].strip().lower() or None
+            data = _read_capped(response, max_bytes)
+            return content_type, data
+        finally:
+            conn.close()
+    raise ImportSecurityError(f"Too many redirects (limit {max_redirects})")

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -596,27 +596,8 @@ def test_vault_import_url_downloads_and_writes_binary(vault_dir, monkeypatch):
     content = b"%PDF fake content"
     checksum = hashlib.sha256(content).hexdigest()
 
-    class FakeHeaders:
-        def get(self, name, default=None):
-            return "application/pdf" if name.lower() == "content-type" else default
-
-    class FakeResponse:
-        headers = FakeHeaders()
-
-        def __init__(self):
-            self._chunks = [content, b""]
-
-        def __enter__(self):
-            return self
-
-        def __exit__(self, *_args):
-            return False
-
-        def read(self, _size):
-            return self._chunks.pop(0)
-
-    monkeypatch.setattr(write_tools, "_validate_import_url", lambda url: None)
-    monkeypatch.setattr(write_tools, "urlopen", lambda request, timeout: FakeResponse())
+    # The SSRF-hardened fetch is exercised in tests/test_url_fetch.py; here we stub it.
+    monkeypatch.setattr(write_tools, "fetch_url", lambda url, **kwargs: ("application/pdf", content))
 
     result = json.loads(
         vault_import_url(
@@ -761,27 +742,7 @@ def test_audit_log_records_mutation_operations(vault_dir, monkeypatch, tmp_path)
         "audit/import-file.pdf",
     )
 
-    class FakeHeaders:
-        def get(self, name, default=None):
-            return "application/pdf" if name.lower() == "content-type" else default
-
-    class FakeResponse:
-        headers = FakeHeaders()
-
-        def __init__(self):
-            self._chunks = [b"%PDF remote", b""]
-
-        def __enter__(self):
-            return self
-
-        def __exit__(self, *_args):
-            return False
-
-        def read(self, _size):
-            return self._chunks.pop(0)
-
-    monkeypatch.setattr(write_tools, "_validate_import_url", lambda url: None)
-    monkeypatch.setattr(write_tools, "urlopen", lambda request, timeout: FakeResponse())
+    monkeypatch.setattr(write_tools, "fetch_url", lambda url, **kwargs: ("application/pdf", b"%PDF remote"))
     run_and_assert(
         "vault_import_url",
         lambda: server.vault_import_url("audit/import-url.pdf", "https://example.invalid/file.pdf", "application/pdf"),

--- a/tests/test_url_fetch.py
+++ b/tests/test_url_fetch.py
@@ -1,0 +1,147 @@
+"""SSRF-hardening regression tests for url_fetch.fetch_url.
+
+Covers the two bypasses a naive guard leaves open: DNS rebinding / TOCTOU (closed by
+single-resolution IP pinning) and redirect-to-internal (closed by per-hop re-validation).
+No network is touched: DNS and the connection layer are substituted.
+"""
+
+import ipaddress
+import socket
+
+import pytest
+
+from obsidian_vault_mcp import url_fetch
+
+
+class _FakeHeaders:
+    def __init__(self, mapping):
+        self._m = {k.lower(): v for k, v in mapping.items()}
+
+    def get(self, key, default=None):
+        return self._m.get(key.lower(), default)
+
+
+class _FakeResponse:
+    def __init__(self, status, headers, body=b""):
+        self.status = status
+        self.headers = _FakeHeaders(headers)
+        self._body = body
+        self._read = False
+
+    def read(self, n=-1):
+        if self._read:
+            return b""
+        self._read = True
+        return self._body
+
+
+class _FakeConn:
+    def __init__(self, response):
+        self._response = response
+
+    def putrequest(self, *a, **k):
+        pass
+
+    def putheader(self, *a, **k):
+        pass
+
+    def endheaders(self, *a, **k):
+        pass
+
+    def getresponse(self):
+        return self._response
+
+    def close(self):
+        pass
+
+
+def _install_dns(monkeypatch, mapping, counter=None):
+    def fake_getaddrinfo(host, port, *a, **k):
+        if counter is not None:
+            counter.append(host)
+        if host not in mapping:
+            raise socket.gaierror(f"no fake DNS entry for {host}")
+        return [(socket.AF_INET, socket.SOCK_STREAM, 0, "", (mapping[host], port))]
+
+    monkeypatch.setattr(socket, "getaddrinfo", fake_getaddrinfo)
+
+
+def _install_conns(monkeypatch, responses, recorder=None):
+    state = {"i": 0}
+
+    def fake_open(scheme, host, pinned_ip, port, timeout):
+        if recorder is not None:
+            recorder.append({"scheme": scheme, "host": host, "pinned_ip": pinned_ip, "port": port})
+        resp = responses[state["i"]]
+        state["i"] += 1
+        return _FakeConn(resp)
+
+    monkeypatch.setattr(url_fetch, "_open_connection", fake_open)
+
+
+_KW = dict(allow_private=False, allowed_ports={80, 443}, max_bytes=1_000_000, max_redirects=5, timeout=5)
+
+
+@pytest.mark.parametrize("addr", ["8.8.8.8", "93.184.216.34"])
+def test_public_ips_pass(addr):
+    assert url_fetch._ip_is_public(ipaddress.ip_address(addr)) is True
+
+
+@pytest.mark.parametrize(
+    "addr",
+    ["127.0.0.1", "10.0.0.5", "192.168.1.1", "169.254.169.254", "::1", "fe80::1", "::ffff:169.254.169.254"],
+)
+def test_non_public_ips_rejected(addr):
+    assert url_fetch._ip_is_public(ipaddress.ip_address(addr)) is False
+
+
+@pytest.mark.parametrize("url", ["file:///etc/passwd", "ftp://host/x", "gopher://h/"])
+def test_validate_url_rejects_bad_scheme(url):
+    with pytest.raises(url_fetch.ImportSecurityError):
+        url_fetch._validate_url(url, {80, 443})
+
+
+def test_validate_url_rejects_disallowed_port():
+    with pytest.raises(url_fetch.ImportSecurityError):
+        url_fetch._validate_url("http://example.com:8080/x", {80, 443})
+
+
+def test_rebinding_closed_resolves_once_and_pins(monkeypatch):
+    """SSRF #1: resolve exactly once and connect to that validated IP (no TOCTOU gap)."""
+    calls, conns = [], []
+    _install_dns(monkeypatch, {"good.example": "93.184.216.34"}, counter=calls)
+    _install_conns(monkeypatch, [_FakeResponse(200, {"Content-Type": "image/png"}, b"PNG")], recorder=conns)
+
+    ctype, data = url_fetch.fetch_url("http://good.example/a.png", **_KW)
+    assert (ctype, data) == ("image/png", b"PNG")
+    assert calls == ["good.example"]
+    assert conns[0]["pinned_ip"] == "93.184.216.34"
+
+
+def test_private_resolution_rejected(monkeypatch):
+    _install_dns(monkeypatch, {"evil.example": "169.254.169.254"})
+    with pytest.raises(url_fetch.ImportSecurityError):
+        url_fetch.fetch_url("http://evil.example/x.png", **_KW)
+
+
+def test_redirect_to_metadata_rejected(monkeypatch):
+    """SSRF #2: a redirect to an internal target is re-validated and refused."""
+    _install_dns(monkeypatch, {"good.example": "93.184.216.34", "169.254.169.254": "169.254.169.254"})
+    _install_conns(monkeypatch, [_FakeResponse(302, {"Location": "http://169.254.169.254/latest/meta-data/"})])
+    with pytest.raises(url_fetch.ImportSecurityError):
+        url_fetch.fetch_url("http://good.example/a.png", **_KW)
+
+
+def test_redirect_budget_enforced(monkeypatch):
+    _install_dns(monkeypatch, {"good.example": "93.184.216.34"})
+    responses = [_FakeResponse(302, {"Location": "http://good.example/again"}) for _ in range(10)]
+    _install_conns(monkeypatch, responses)
+    with pytest.raises(url_fetch.ImportSecurityError):
+        url_fetch.fetch_url("http://good.example/a.png", **{**_KW, "max_redirects": 2})
+
+
+def test_size_cap_enforced(monkeypatch):
+    _install_dns(monkeypatch, {"good.example": "93.184.216.34"})
+    _install_conns(monkeypatch, [_FakeResponse(200, {"Content-Type": "image/png"}, b"x" * 50)])
+    with pytest.raises(url_fetch.ImportFetchError):
+        url_fetch.fetch_url("http://good.example/a.png", **{**_KW, "max_bytes": 10})


### PR DESCRIPTION
Harden vault_import_url against SSRF. The previous guard (resolve host, check IP, then urlopen) left two standard bypasses open; both closed in a new url_fetch module.

DNS rebinding / TOCTOU - validator and urlopen resolved the hostname independently; a hostile DNS could pass a public IP to the check and a private IP (169.254.169.254, loopback) to the connect. fetch_url now resolves ONCE and pins the connection to the validated IP, preserving the original Host header and TLS SNI/cert hostname.

Redirects - urlopen auto-followed 30x and only the first URL was validated. No auto-redirects now; every hop is re-validated and re-pinned, bounded by VAULT_IMPORT_URL_MAX_REDIRECTS (default 5).

Defense in depth: public-IP-only by default (is_global, IPv4-mapped IPv6 unwrapped), scheme allowlist, port allowlist VAULT_IMPORT_URL_ALLOWED_PORTS (default 80,443). VAULT_IMPORT_URL_ALLOW_PRIVATE stays the explicit opt-in. The hardened fetcher mirrors the obsidian-vault-mcp-ext ImportExtension.

Tests: tests/test_url_fetch.py adds rebinding-closed and redirect-to-metadata regressions plus IP/scheme/port/budget/size-cap; existing import tests stub the fetch_url seam. Full suite: 340 passed, 1 skipped.