### PR TITLE
security: harden binary allowlist + atomic write + analytics read cap (v0.8.14)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,18 @@ This project follows semantic versioning. Release dates use YYYY-MM-DD.
 
 ## [Unreleased]
 
+## [v0.8.14] - 2026-06-18
+
+### Security
+- **`image/svg+xml` removed from the default binary allowlist.** SVG is the one entry that is not inert: it can carry `<script>`/`onload`. Because `_validate_binary_target` gates only on the declared `media_type` + extension and never sniffs bytes, allowing it was an arbitrary-active-content write into a vault that may be synced or rendered in a preview surface. This hardens all three binary entry points (`vault_write_binary`, `vault_import_url`, `vault_import_file`). PNG/JPEG/WEBP/GIF/PDF (all inert) remain; SVG can be re-enabled deliberately via `VAULT_EXTRA_BINARY_MEDIA_TYPES_JSON`. Surfaced by the upstream review of mleitnercom's `vault_write_binary` PR (jimprosser/obsidian-web-mcp#61).
+
+### Fixed
+- **`write_bytes_atomic` no-clobber is now atomic.** With `overwrite=False` it used `exists()`-then-`os.replace`, a check-then-write race that could still clobber a file created in between. It now uses `os.link`, which fails atomically if the target exists. (jimprosser/obsidian-web-mcp#61 review)
+- **Vault analytics no longer reads whole files unbounded.** `analytics._load_posts` pulled every markdown file fully into memory; one pathological multi-hundred-MB note (or a very large vault) could spike memory on the tunnel-reachable server. It now reads at most `MAX_CONTENT_SIZE` (1 MB) per file (top-of-file frontmatter still parses) and drops the per-post duplicate `text`/`name` fields that nothing consumed. (jimprosser/obsidian-web-mcp#59 review)
+
+### Notes
+- All three were found by Jim's upstream review of the analogous contributions; this release backports the same hardening to the fork's live, tunnel-exposed deployment.
+
 ## [v0.8.13] - 2026-06-16
 
 ### Security

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Production-hardened fork of [`jimprosser/obsidian-web-mcp`](https://github.com/jimprosser/obsidian-web-mcp): an HTTP-based MCP server that exposes an Obsidian vault to LLM clients such as Claude, ChatGPT, and Codex over OAuth 2.0.
 
-**Latest release:** [v0.8.13](https://github.com/mleitnercom/obsidian-web-mcp/releases/tag/v0.8.13) (2026-06-16)
+**Latest release:** [v0.8.14](https://github.com/mleitnercom/obsidian-web-mcp/releases/tag/v0.8.14) (2026-06-18)
 
 ## At a Glance
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "obsidian-web-mcp"
-version = "0.8.13"
+version = "0.8.14"
 description = "Secure remote MCP server for Obsidian vaults -- access your notes from Claude, your phone, or any MCP client, anywhere"
 readme = "README.md"
 requires-python = ">=3.12"

--- a/src/obsidian_vault_mcp/tools/analytics.py
+++ b/src/obsidian_vault_mcp/tools/analytics.py
@@ -18,6 +18,11 @@ from ..vault import (
 
 WIKILINK_RE = re.compile(r"\[\[([^\]]+)\]\]")
 
+# Per-file read cap for analysis, aligned with the 1 MB write cap. A file over this is read
+# only up to the cap (so top-of-file frontmatter still parses), so one pathological note
+# can't spike memory on the tunnel-reachable server.
+_MAX_ANALYZE_BYTES = config.MAX_CONTENT_SIZE
+
 
 def _iter_vault_files(path_prefix: str = "", pattern: str = "*") -> tuple[Path, list[Path]]:
     if path_prefix:
@@ -58,26 +63,32 @@ def _load_posts(path_prefix: str = "") -> tuple[list[dict], dict[str, list[str]]
 
     for path in files:
         rel = str(path.relative_to(vault_root)).replace("\\", "/")
+        # Cap the per-file read so one pathological note can't spike memory.
         try:
-            raw = path.read_text(encoding="utf-8")
+            oversized = path.stat().st_size > _MAX_ANALYZE_BYTES
+        except OSError:
+            oversized = False
+        try:
+            if oversized:
+                with path.open("r", encoding="utf-8", errors="ignore") as handle:
+                    raw = handle.read(_MAX_ANALYZE_BYTES)
+            else:
+                raw = path.read_text(encoding="utf-8")
             post = frontmatter.loads(raw)
             metadata = dict(post.metadata)
             body = post.content
         except UnicodeDecodeError:
-            raw = ""
             metadata = {}
             body = ""
         except Exception:
-            raw = path.read_text(encoding="utf-8", errors="ignore")
+            with path.open("r", encoding="utf-8", errors="ignore") as handle:
+                body = handle.read(_MAX_ANALYZE_BYTES)
             metadata = {}
-            body = raw
         posts.append(
             {
                 "path": rel,
-                "text": raw,
                 "body": body,
                 "frontmatter": metadata,
-                "name": path.stem,
             }
         )
 

--- a/src/obsidian_vault_mcp/tools/write.py
+++ b/src/obsidian_vault_mcp/tools/write.py
@@ -27,12 +27,15 @@ from ..vault import (
 
 logger = logging.getLogger(__name__)
 
+# Only inert formats. SVG is intentionally excluded: it can carry <script>/onload, and
+# validation is by declared media_type + extension (not byte-sniffing), so allowing it would
+# be an arbitrary-active-content write into a synced/rendered vault. Opt back in deliberately
+# via VAULT_EXTRA_BINARY_MEDIA_TYPES_JSON if you really need it.
 DEFAULT_ALLOWED_BINARY_MEDIA_TYPES = {
     "image/png": {".png"},
     "image/jpeg": {".jpg", ".jpeg"},
     "image/webp": {".webp"},
     "image/gif": {".gif"},
-    "image/svg+xml": {".svg"},
     "application/pdf": {".pdf"},
 }
 

--- a/src/obsidian_vault_mcp/vault.py
+++ b/src/obsidian_vault_mcp/vault.py
@@ -512,9 +512,6 @@ def write_bytes_atomic(
     path = resolve_vault_path(relative_path)
     is_new = not path.exists()
 
-    if not overwrite and not is_new:
-        raise FileExistsError(f"File already exists: {relative_path}")
-
     if create_dirs:
         path.parent.mkdir(parents=True, exist_ok=True)
 
@@ -522,7 +519,21 @@ def write_bytes_atomic(
     try:
         with os.fdopen(fd, "wb") as f:
             f.write(content)
-        os.replace(tmp_path, path)
+        if overwrite:
+            os.replace(tmp_path, path)
+        else:
+            # Atomic no-clobber: os.link fails if the target exists, closing the
+            # check-then-write race that exists()-then-os.replace would leave open.
+            try:
+                os.link(tmp_path, path)
+            except FileExistsError:
+                raise FileExistsError(f"File already exists: {relative_path}")
+            finally:
+                try:
+                    os.unlink(tmp_path)
+                except OSError:
+                    pass
+            is_new = True
     except BaseException:
         try:
             os.unlink(tmp_path)

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -500,6 +500,30 @@ def test_vault_write_binary_creates_png(vault_dir):
     assert (vault_dir / "assets" / "visual.png").read_bytes() == png_bytes
 
 
+def test_vault_write_binary_rejects_svg(vault_dir):
+    """SVG is no longer in the default allowlist (active-content hardening, v0.8.14)."""
+    result = json.loads(
+        vault_write_binary(
+            "assets/icon.svg",
+            base64.b64encode(b"<svg onload=alert(1)/>").decode("ascii"),
+            "image/svg+xml",
+        )
+    )
+    assert "Unsupported media_type" in result["error"]
+    assert not (vault_dir / "assets" / "icon.svg").exists()
+
+
+def test_analytics_load_posts_caps_oversized_read(vault_dir, monkeypatch):
+    """_load_posts reads at most the cap per file and drops the duplicate text/name fields."""
+    from obsidian_vault_mcp.tools import analytics
+    monkeypatch.setattr(analytics, "_MAX_ANALYZE_BYTES", 100)
+    (vault_dir / "huge.md").write_text("---\nstatus: active\n---\n" + ("x" * 5000), encoding="utf-8")
+    posts, _, _ = analytics._load_posts()
+    hit = next(p for p in posts if p["path"] == "huge.md")
+    assert len(hit["body"]) <= 100
+    assert "text" not in hit and "name" not in hit
+
+
 def test_vault_write_binary_rejects_media_type_mismatch(vault_dir):
     """vault_write_binary rejects a mismatched extension and media type."""
     result = json.loads(


### PR DESCRIPTION
Backports three issues Jim surfaced in upstream review of the analogous PRs, into the live tunnel-exposed fork:

- **SVG out of the default binary allowlist** (active content; allowlist gates declared type/extension, not bytes) — hardens vault_write_binary + vault_import_url/_file; re-enable via VAULT_EXTRA_BINARY_MEDIA_TYPES_JSON. (#61 review)
- **write_bytes_atomic atomic no-clobber** via os.link instead of exists()-then-replace. (#61 review)
- **analytics per-file read cap** (1 MB bounded read) + dropped unused text/name fields — no memory spike. (#59 review)

Full suite green on Linux: 343 passed. v0.8.14.